### PR TITLE
Remove multiple calls that count the number of tokens.

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/TokenList.java
+++ b/core/src/main/java/org/kohsuke/stapler/TokenList.java
@@ -41,8 +41,9 @@ public final class TokenList {
 
     TokenList(String url) {
         StringTokenizer tknzr = new StringTokenizer(url,"/");
-        tokens = new String[tknzr.countTokens()];
-        rawTokens = new String[tknzr.countTokens()];
+        final int tokenCount = tknzr.countTokens();
+        tokens = new String[tokenCount];
+        rawTokens = new String[tokenCount];
         for(int i=0; tknzr.hasMoreTokens(); i++) {
             rawTokens[i] = tknzr.nextToken();
             tokens[i] = decode(rawTokens[i]);


### PR DESCRIPTION
`StringTokenizer.countTokens` was called twice in the same method which causes the url to be traversed more times than necessary.
