### PR TITLE
[STAPLER-15] Root element names are different between XML and XSD

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/export/SchemaGenerator.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/SchemaGenerator.java
@@ -25,6 +25,7 @@ package org.kohsuke.stapler.export;
 
 import com.sun.xml.txw2.TXW;
 import com.sun.xml.txw2.output.ResultFactory;
+import java.beans.Introspector;
 import org.kohsuke.stapler.export.XSD.ComplexType;
 import org.kohsuke.stapler.export.XSD.ContentModel;
 import org.kohsuke.stapler.export.XSD.Element;
@@ -72,7 +73,7 @@ public class SchemaGenerator {
         written.clear();
 
         // element decl for the root element
-        s.element().name(top.type.getSimpleName()).type(getXmlTypeName(top.type));
+        s.element().name(Introspector.decapitalize(top.type.getSimpleName())).type(getXmlTypeName(top.type));
 
         // write all beans
         while(!queue.isEmpty())


### PR DESCRIPTION
This pull request fixes [STAPLER-15](http://java.net/jira/browse/STAPLER-15).

To minimize an impact, it would be better to change XSD.
- https://github.com/stapler/stapler/blob/stapler-parent-1.174/core/src/main/java/org/kohsuke/stapler/export/XMLDataWriter.java#L50
- https://github.com/stapler/stapler/blob/stapler-parent-1.174/core/src/main/java/org/kohsuke/stapler/export/SchemaGenerator.java#L75
