### PR TITLE
Use Object.toJSON instead of Array.toJSON

### DIFF
--- a/core/src/main/resources/org/kohsuke/stapler/bind.js
+++ b/core/src/main/resources/org/kohsuke/stapler/bind.js
@@ -24,7 +24,7 @@ function makeStaplerProxy(url,crumb,methods) {
             new Ajax.Request(url+methodName, {
                 method: 'post',
                 requestHeaders: {'Content-type':'application/x-stapler-method-invocation;charset=UTF-8','Crumb':crumb},
-                postBody: a.toJSON(),
+                postBody: Object.toJSON(a),
                 onSuccess: function(t) {
                     if (callback!=null) {
                         t.responseObject = function() {


### PR DESCRIPTION
Prototype.js 1.7 does not provide Array.toJSON.
It is better to use Object.toJSON for both of old prototype.js and new one.

See also https://github.com/jenkinsci/jenkins/pull/276#issuecomment-2626039
