### PR TITLE
Request to update Maven repositories.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,14 @@
       <id>r.m.a.o-maven2</id>
       <url>http://repo1.maven.apache.org/maven2/</url>
     </repository>
+    <repository>
+      <id>m.j-c.o-artifacts</id>
+      <url>http://maven.jenkins-ci.org/content/groups/artifacts/</url>
+    </repository>
+    <repository>
+      <id>m.g.o-public</id>
+      <url>http://maven.glassfish.org/content/groups/public/</url>
+    </repository>
   </repositories>
 
   <pluginRepositories>


### PR DESCRIPTION
Hi!

Please review the changes.

I have updated Maven repositories in pom.xml to maven.apache.org and jenkins-ci.org, because glassfish.org does not contain all required artifacts for the successful project build.

Tested it by flushing local repo and rebuilding the project (clean install).

http://java.net/jira/browse/STAPLER-18
