### PR TITLE
[STAPLER-17] Changed content type for JSON flavor to "application/json"

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/export/Flavor.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Flavor.java
@@ -34,7 +34,7 @@ import java.io.Writer;
  * @author Kohsuke Kawaguchi
  */
 public enum Flavor {
-    JSON("application/javascript;charset=UTF-8") {
+    JSON("application/json;charset=UTF-8") {
         public DataWriter createDataWriter(Object bean, Writer w, ExportConfig config) throws IOException {
             return new JSONDataWriter(w,config);
         }


### PR DESCRIPTION
Hi! Please review the change.

While working on https://issues.jenkins-ci.org/browse/JENKINS-13541 I discovered that in Jenkins we set response content type based on the requested flavor and the value is taken from Stapler Framework Flavor enumeration. I have updated Flavor code to make JSON responses from Jenkins compliant with RFC4627 (http://www.ietf.org/rfc/rfc4627.txt)
