### PR TITLE
Upgrade to JRuby 1.7.3

### DIFF
--- a/jruby/pom.xml
+++ b/jruby/pom.xml
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>org.jruby</groupId>
       <artifactId>jruby-complete</artifactId>
-      <version>1.6.1</version>
+      <version>1.7.3</version>
     </dependency>
     <dependency>
       <groupId>org.jruby.rack</groupId>
       <artifactId>jruby-rack</artifactId>
-      <version>1.0.10</version>
+      <version>1.1.13.1</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/jruby/src/main/java/org/kohsuke/stapler/jelly/jruby/RackDispatcher.java
+++ b/jruby/src/main/java/org/kohsuke/stapler/jelly/jruby/RackDispatcher.java
@@ -5,10 +5,7 @@ import org.jruby.RubyModule;
 import org.jruby.RubyObject;
 import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.rack.DefaultRackApplication;
-import org.jruby.rack.servlet.ServletRackConfig;
-import org.jruby.rack.servlet.ServletRackContext;
-import org.jruby.rack.servlet.ServletRackEnvironment;
-import org.jruby.rack.servlet.ServletRackResponseEnvironment;
+import org.jruby.rack.servlet.*;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.kohsuke.stapler.Dispatcher;
 import org.kohsuke.stapler.RequestImpl;
@@ -35,11 +32,11 @@ public class RackDispatcher extends Dispatcher {
             return false;
 
         // TODO: does the context need to live longer?
-        ServletRackContext rackContext = new ServletRackContext(new ServletRackConfig(req.getServletContext()));
+        ServletRackContext rackContext = new DefaultServletRackContext(new ServletRackConfig(req.getServletContext()));
 
         // we don't want the Rack app to consider the portion of the URL that was already consumed
         // to reach to the Rack app, so for PATH_INFO we use getRestOfPath(), not getPathInfo()
-        ServletRackEnvironment env = new ServletRackEnvironment(req, rackContext) {
+        ServletRackEnvironment env = new ServletRackEnvironment(req, rsp, rackContext) {
             @Override
             public String getPathInfo() {
                 return req.getRestOfPath();

--- a/jruby/src/main/resources/org/kohsuke/stapler/jelly/jruby/erb/JRubyJellyERbScript.rb
+++ b/jruby/src/main/resources/org/kohsuke/stapler/jelly/jruby/erb/JRubyJellyERbScript.rb
@@ -40,6 +40,11 @@ module JRubyJellyScriptImpl
       def concat(str)
         output.write(str) if str
       end
+
+      # ERB calls this during initialization
+      def force_encoding(enc)
+        self
+      end
     end
   end
 end


### PR DESCRIPTION
Jenkins recently upgraded to BouncyCastle 1.47 which created an incompatibility with the JRuby 1.6.5 version used for the Ruby runtime plugin.  JRuby 1.7.3+ is using BC 1.47 as well now but updating the Ruby runtime plugin isn't enough because the Erb.rb now calls force_encoding which was throwing an error when executing ERBs since the output stream didn't have support for that method.
