### PR TITLE
Load JRebel integration using reflection.

### DIFF
--- a/jrebel/pom.xml
+++ b/jrebel/pom.xml
@@ -23,12 +23,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.zeroturnaround</groupId>
-      <artifactId>jr-sdk</artifactId>
-      <version>2.1.1</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.kohsuke.metainf-services</groupId>
       <artifactId>metainf-services</artifactId>
       <optional>true</optional>


### PR DESCRIPTION
Hoping this might solve a problem with `jmap`. Since I cannot reproduce that problem, I cannot tell—this is just an experiment.

Note that I do not personally have JRebel so I cannot test whether the reloading still works when it _is_ present; I just checked that Jenkins starts quietly when it is not.
