### PR TITLE
AncestorImpl#getRelativePath doesn't return correct value if url doesn't end with /

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/AncestorImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/AncestorImpl.java
@@ -89,7 +89,9 @@ class AncestorImpl implements Ancestor {
 
     public String getRelativePath() {
         StringBuilder buf = new StringBuilder();
-        for( int i=index; i<tokens.length; i++ ) {
+        StaplerRequest req = Stapler.getCurrentRequest();
+        int delta = req.getServletPath().endsWith("/") ? 0 : 1;
+        for( int i=index+delta; i<tokens.length; i++ ) {
             if(buf.length()>0)  buf.append('/');
             buf.append("..");
         }


### PR DESCRIPTION
If the servlet path doesn't end with /, then the computed relative path
should be shifted by one level.
