### PR TITLE
Emit "bytes" as part of Content-Range header per RFC2616.

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/Stapler.java
+++ b/core/src/main/java/org/kohsuke/stapler/Stapler.java
@@ -493,7 +493,7 @@ public class Stapler extends HttpServlet {
 
                         // ritual for responding to a partial GET
                         rsp.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
-                        rsp.setHeader("Content-Range",s+"-"+(e-1)+'/'+contentLength); // end is inclusive.
+                        rsp.setHeader("Content-Range","bytes "+s+"-"+(e-1)+'/'+contentLength); // end is inclusive.
 
                         // prepare to send the partial content
                         DataInputStream dis = new DataInputStream(in);


### PR DESCRIPTION
Makes it work with Chrome and fixes JENKINS-13125.

See https://issues.jenkins-ci.org/browse/JENKINS-13125?focusedCommentId=181459&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-181459
