### PR TITLE
Use 'owner.webApp' instead of 'WebApp.getCurrent()' in JellyClassTearOff

### DIFF
--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyClassTearOff.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyClassTearOff.java
@@ -49,7 +49,7 @@ public class JellyClassTearOff extends AbstractTearOff<JellyClassLoaderTearOff,S
 
     public JellyClassTearOff(MetaClass owner) {
         super(owner,JellyClassLoaderTearOff.class);
-        facet = WebApp.getCurrent().getFacet(JellyFacet.class);
+        facet = owner.webApp.getFacet(JellyFacet.class);
     }
 
     protected Script parseScript(URL res) throws JellyException {


### PR DESCRIPTION
Rely on our 'owner' for providing the appropriate 'WebApp' (as we already do lower in the file), to avoid a dependency on 'WebApp.getCurrent()' and transitively 'Stapler.getCurrent()', which mandate that this be executed from a request context.
