### PR TITLE
[FIXED JENKINS-11543] Use request charset for multipart form JSON

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
@@ -852,8 +852,19 @@ public class RequestImpl extends HttpServletRequestWrapper implements StaplerReq
                 isSubmission=true;
                 parseMultipartFormData();
                 FileItem item = parsedFormData.get("json");
-                if(item!=null)
-                    p = item.getString();
+                if(item!=null) {
+                    if (item.getContentType() == null) {
+                        // JENKINS-11543: If client doesn't set charset per part, use request encoding
+                        try {
+                            p = item.getString(getCharacterEncoding());
+                        } catch (java.io.UnsupportedEncodingException uee) {
+                            LOGGER.log(WARNING, "Request has unsupported charset, using default for 'json' parameter", uee);
+                            p = item.getString();
+                        }
+                    } else {
+                        p = item.getString();
+                    }
+                }
             } else {
                 p = getParameter("json");
                 isSubmission = !getParameterMap().isEmpty();


### PR DESCRIPTION
Not sure this is the correct approach for this issue, but I couldn't figure out how to set a character encoding per part of the multipart request in the client.
