### PR TITLE
This shifts the attribute used by Stapler from 'stapler-class' to '$class'.

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
@@ -569,10 +569,8 @@ public class RequestImpl extends HttpServletRequestWrapper implements StaplerReq
                     try {
                         Class actualType = type;
                         String className = null;
-                        if(j.has("stapler-class")) {
-                            className = j.getString("stapler-class");
-                        } else if(j.has("kind")) {
-                            className = j.getString("kind");
+                        if(j.has("$class")) {
+                            className = j.getString("$class");
                         }
 
                         if (className != null) {

--- a/core/src/main/java/org/kohsuke/stapler/StaplerRequest.java
+++ b/core/src/main/java/org/kohsuke/stapler/StaplerRequest.java
@@ -395,7 +395,7 @@ public interface StaplerRequest extends HttpServletRequest {
      * <h3>Sub-typing</h3>
      * <p>
      * In the above example, a new instance of <tt>Bar</tt> was created,
-     * but you can also create a subtype of Bar by having the 'stapler-class' property in
+     * but you can also create a subtype of Bar by having the '$class' property in
      * JSON like this:
      *
      * <pre>
@@ -404,7 +404,7 @@ public interface StaplerRequest extends HttpServletRequest {
      *   public BarEx(int a, int b, int c) {}
      * }
      *
-     * { y:"text", z:true, bar: { stapler-class:"p.k.g.BarEx", a:1, b:2, c:3 } }
+     * { y:"text", z:true, bar: { $class:"p.k.g.BarEx", a:1, b:2, c:3 } }
      * </pre>
      *
      * <p>

--- a/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
@@ -250,7 +250,7 @@ public class DataBindingTest extends TestCase {
     }
 
     public void testSetterInvocation() {
-        SetterBinding r = bind("{x:1,y:2,z:3,w:1, children:[{x:5,y:5,z:5},{x:6,y:6,z:6}], anotherObject:{kind:'org.kohsuke.stapler.DataBindingTest$Point', x:1,y:1} }",SetterBinding.class);
+        SetterBinding r = bind("{x:1,y:2,z:3,w:1, children:[{x:5,y:5,z:5},{x:6,y:6,z:6}], anotherObject:{$class:'org.kohsuke.stapler.DataBindingTest$Point', x:1,y:1} }",SetterBinding.class);
         assertEquals(1,r.x);
         assertEquals(2,r.y);
         assertEquals(3,r.z);
@@ -345,7 +345,7 @@ public class DataBindingTest extends TestCase {
             }
         });
 
-        Object[] r = (Object[]) req.bindJSON(Object[].class, Object[].class, JSONArray.fromObject("[{stapler-class:'"+Point.class.getName()+"'}]"));
+        Object[] r = (Object[]) req.bindJSON(Object[].class, Object[].class, JSONArray.fromObject("[{$class:'"+Point.class.getName()+"'}]"));
         assertTrue(Arrays.equals(r,new Object[]{new Point(1,2)}));
     }
 

--- a/core/src/test/java/org/kohsuke/stapler/NestedJsonTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/NestedJsonTest.java
@@ -35,7 +35,7 @@ public class NestedJsonTest extends TestCase {
     }
 
     public void testCreateObject() throws Exception {
-        Foo o = createRequest().bindJSON(Foo.class, createDataSet(KIND));
+        Foo o = createRequest().bindJSON(Foo.class, createDataSet());
 
         assertNotNull(o);
         assertTrue(o.bar instanceof BarImpl);
@@ -44,7 +44,7 @@ public class NestedJsonTest extends TestCase {
 
     public void testInstanceFill() throws Exception {
         Foo o = new Foo(null);
-        createRequest().bindJSON(o, createDataSet(STAPLER_CLASS));
+        createRequest().bindJSON(o, createDataSet());
         
         assertTrue(o.bar instanceof BarImpl);
         assertEquals(123, ((BarImpl)o.bar).i);
@@ -52,7 +52,7 @@ public class NestedJsonTest extends TestCase {
 
     public void testCreateList() throws Exception {
         // Just one
-        List<Foo> list = createRequest().bindJSONToList(Foo.class, createDataSet(KIND));
+        List<Foo> list = createRequest().bindJSONToList(Foo.class, createDataSet());
         assertNotNull(list);
         assertEquals(1, list.size());
         assertTrue(list.get(0).bar instanceof BarImpl);
@@ -60,9 +60,10 @@ public class NestedJsonTest extends TestCase {
 
         // Longer list
         JSONArray data = new JSONArray();
-        data.add(createDataSet(STAPLER_CLASS));
-        data.add(createDataSet(KIND));
-        data.add(createDataSet(STAPLER_CLASS));
+        data.add(createDataSet());
+        data.add(createDataSet());
+        data.add(createDataSet());
+
         list = createRequest().bindJSONToList(Foo.class, data);
         assertNotNull(list);
         assertEquals(3, list.size());
@@ -73,17 +74,15 @@ public class NestedJsonTest extends TestCase {
         return new RequestImpl(createStapler(), new MockRequest(), Collections.EMPTY_LIST,null);
     }
 
-    private JSONObject createDataSet(String keyword) {
+    private JSONObject createDataSet() {
         JSONObject bar = new JSONObject();
         bar.put("i",123);
         JSONObject foo = new JSONObject();
         foo.put("bar",bar);
-        foo.getJSONObject("bar").put(keyword, BarImpl.class.getName());
+        foo.getJSONObject("bar").put("$class", BarImpl.class.getName());
+
         return foo;
     }
-
-    private static final String STAPLER_CLASS = "stapler-class";
-    private static final String KIND = "kind";
 
     private Stapler createStapler() throws ServletException {
         Stapler stapler = new Stapler();


### PR DESCRIPTION
Today, Jenkins uses a mix of stapler's data-binding and its own.  The former uses a lot of 'stapler-class[-bag]' annotations, whereas the latter uses 'kind'.  Various jelly elements emit both because they aren't sure which is needed.

This change allows Stapler to accept 'kind' in addition to 'stapler-class', so that a single-consistent term may be used for all contexts.

NOTE: The bias here is towards 'kind' because this keyword choice directly affects the grammar of the yaml-project plugin, and is a more user friendly keyword for the YAML DSL.
