### PR TITLE
A NPE will be thrown if a forum submission does not have encoding.

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
@@ -853,7 +853,7 @@ public class RequestImpl extends HttpServletRequestWrapper implements StaplerReq
                 parseMultipartFormData();
                 FileItem item = parsedFormData.get("json");
                 if(item!=null) {
-                    if (item.getContentType() == null) {
+                    if (item.getContentType() == null && getCharacterEncoding() != null) {
                         // JENKINS-11543: If client doesn't set charset per part, use request encoding
                         try {
                             p = item.getString(getCharacterEncoding());


### PR DESCRIPTION
This happens with the credentials plugin and uploading a developers profile. If there is no encoding type it will throw a NPE: charsetName.
