### PR TITLE
[JENKINS-25167] Warn when @Exported method requires arguments

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/export/Model.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Model.java
@@ -36,6 +36,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
@@ -93,8 +95,13 @@ public class Model<T> {
         for( Method m : type.getMethods() ) {
             if(m.getDeclaringClass()!=type) continue;
             Exported exported = m.getAnnotation(Exported.class);
-            if(exported !=null)
-                properties.add(new MethodProperty(this,m, exported));
+            if(exported !=null) {
+                if (m.getParameterTypes().length > 0) {
+                    LOGGER.log(Level.WARNING, "Method " + m.getName() + " of " + type.getName() + " is annotated @Exported but requires arguments");
+                } else {
+                    properties.add(new MethodProperty(this,m, exported));
+                }
+            }
         }
 
         this.properties = properties.toArray(new Property[properties.size()]);
@@ -191,4 +198,6 @@ public class Model<T> {
             }
         }
     }
+
+    private static final Logger LOGGER = Logger.getLogger(Model.class.getName());
 }


### PR DESCRIPTION
Methods that are `@Exported` but shouldn't be will no longer break the API with an `IllegalArgumentException` that explains nothing. Now, the property is skipped from the output, and a warning logged:

> Okt 17, 2014 1:03:45 AM org.kohsuke.stapler.export.Model <init>
> WARNING: Method getTooltip of hudson.plugins.analysis.core.AbstractResultAction is annotated @Exported but requires arguments
