### PR TITLE
Use Java 7 versions of `GZIPInputStream` and `GZIPOutputStream`

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,11 +16,6 @@
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>com.jcraft</groupId>
-      <artifactId>jzlib</artifactId>
-      <version>1.1.3-kohsuke-1</version>
-    </dependency>
     <!-- optional REST support -->
     <dependency>
       <groupId>com.sun.xml.txw2</groupId>

--- a/core/src/main/java/org/kohsuke/stapler/ResponseImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/ResponseImpl.java
@@ -23,7 +23,6 @@
 
 package org.kohsuke.stapler;
 
-import com.jcraft.jzlib.GZIPOutputStream;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.ByteArrayOutputStream;
@@ -40,6 +39,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.zip.GZIPOutputStream;
 import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;

--- a/core/src/main/java/org/kohsuke/stapler/Stapler.java
+++ b/core/src/main/java/org/kohsuke/stapler/Stapler.java
@@ -927,7 +927,7 @@ public class Stapler extends HttpServlet {
             return true;
         }
         if (x instanceof IOException
-                && "finished".equals(x.getMessage())) { // com.jcraft.jzlib.DeflaterOutputStream.write
+                && "write beyond end of stream".equals(x.getMessage())) { // java.util.zip.DeflaterOutputStream.write
             return true;
         }
         return isSocketException(x.getCause());

--- a/core/src/main/java/org/kohsuke/stapler/compression/CompressionServletResponse.java
+++ b/core/src/main/java/org/kohsuke/stapler/compression/CompressionServletResponse.java
@@ -1,9 +1,9 @@
 package org.kohsuke.stapler.compression;
 
-import com.jcraft.jzlib.GZIPOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.util.zip.GZIPOutputStream;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;

--- a/core/src/main/java/org/kohsuke/stapler/framework/io/LargeText.java
+++ b/core/src/main/java/org/kohsuke/stapler/framework/io/LargeText.java
@@ -25,7 +25,6 @@
 
 package org.kohsuke.stapler.framework.io;
 
-import com.jcraft.jzlib.GZIPInputStream;
 import java.io.Closeable;
 import java.io.DataInputStream;
 import java.io.EOFException;
@@ -40,6 +39,7 @@ import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
+import java.util.zip.GZIPInputStream;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.io.output.CountingOutputStream;
 import org.kohsuke.stapler.StaplerRequest;


### PR DESCRIPTION
See jenkinsci/workflow-api-plugin#134, jenkinsci/cloudbees-folder-plugin#174, and jenkinsci/docker-build-step-plugin#75. [JZlib](https://github.com/ymnk/jzlib) has not been updated since 2013. Since then, [`GZIPInputStream`](https://docs.oracle.com/javase/8/docs/api/java/util/zip/GZIPInputStream.html) and [`GZIPOutputStream`](https://docs.oracle.com/javase/8/docs/api/java/util/zip/GZIPOutputStream.html) have been added to the Java 7 API, so it seems more prudent to use those implementations.

To verify the correctness of the change to `Stapler#isSocketException(Throwable)`, compare the upstream error messages from [JZlib](https://github.com/ymnk/jzlib/blob/a21be20213d66eff15904d925e9b721956a01ef7/src/main/java/com/jcraft/jzlib/DeflaterOutputStream.java#L90) and [AdoptOpenJDK](https://github.com/AdoptOpenJDK/openjdk-jdk8u/blob/9a91972c76ddda5c1ce28b50ca38cbd8a30b7a72/jdk/src/share/classes/java/util/zip/DeflaterOutputStream.java#L201).