### PR TITLE
Escape control characters

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/Stapler.java
+++ b/core/src/main/java/org/kohsuke/stapler/Stapler.java
@@ -1185,10 +1185,30 @@ public class Stapler extends HttpServlet {
             if(ch=='&')
                 buf.append("&amp;");
             else
+            if (isControlCharacter(ch)) {
+                buf.append("&#");
+                buf.append(Integer.toString(ch, 10));
+                buf.append(';');
+            } else
                 buf.append(ch);
         }
         if (buf.length()==v.length())   return  v;  // unmodified
         return buf.toString();
+    }
+
+    /**
+     * Determine whether the character is a control character. Such control characters are only
+     * valid in certain contexts in XML 1.1 documents, and their usage is restricted and highly
+     * discouraged.
+     *
+     * @param c The character to check.
+     * @return Whether the character is a control character.
+     */
+    private static boolean isControlCharacter(char c) {
+        if (c == '\t' || c == '\n' || c == '\r' || (c >= ' ' && c <= '~') || c == 0x0085) {
+            return false;
+        }
+        return c >= 0x0001 && c <= 0x009F;
     }
 
     public static Object[] htmlSafeArguments(Object[] args) {

--- a/core/src/test/java/org/kohsuke/stapler/export/XMLDataWriterTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/XMLDataWriterTest.java
@@ -117,6 +117,21 @@ public class XMLDataWriterTest extends TestCase {
                 serialize(new X(), X.class));
     }
 
+    @ExportedBean
+    public static class Escape {
+        @Exported
+        public String foo =
+                "\u0001\u0008\t\n\u000B\u000C\r\u000E\u001F &<>A-Za-z0-9~\u007F\u0084\u0085\u0086\u009F\u00A0";
+    }
+
+    public void testEscape() throws Exception {
+        String s = serialize(new Escape(), Escape.class);
+        assertValidXML("<?xml version=\"1.1\"?>" + s);
+        assertEquals(
+                "<escape _class='Escape'><foo>&#1;&#8;\t\n&#11;&#12;\r&#14;&#31; &amp;&lt;&gt;A-Za-z0-9~&#127;&#132;\u0085&#134;&#159;\u00A0</foo></escape>",
+                s);
+    }
+
     @ExportedBean(defaultVisibility=2) public static abstract class Super {
         @Exported public String basic = "super";
         @Exported public abstract String generic();


### PR DESCRIPTION
See [Valid characters in XML](https://en.wikipedia.org/wiki/Valid_characters_in_XML). These are usually a sign that something else is going wrong, but unprintable characters are exceedingly difficult to debug. Escaping them at least makes them more visible and aids in diagnosis.