### PR TITLE
Use Java 8 in annotation tests

### DIFF
--- a/core/src/test/java/org/kohsuke/stapler/jsr269/ConstructorProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/ConstructorProcessorTest.java
@@ -19,7 +19,7 @@ public class ConstructorProcessorTest {
                 addLine("public class Stuff {").
                 addLine("  @DataBoundConstructor public Stuff(int count, String name) {}").
                 addLine("}");
-        compilation.doCompile(null, "-source", "6");
+        compilation.doCompile(null, "-source", "8", "-Xlint:none");
         assertEquals(Collections.emptyList(), compilation.getDiagnostics());
         assertEquals("{constructor=count,name}", Utils.normalizeProperties(Utils.getGeneratedResource(compilation, "some/pkg/Stuff.stapler")));
     }
@@ -31,7 +31,7 @@ public class ConstructorProcessorTest {
                 addLine("public class Stuff {").
                 addLine("  /** @stapler-constructor */ public Stuff(String name, int count) {}").
                 addLine("}");
-        compilation.doCompile(null, "-source", "6");
+        compilation.doCompile(null, "-source", "8", "-Xlint:none");
         assertEquals(Collections.emptyList(), compilation.getDiagnostics());
         assertEquals("{constructor=name,count}", Utils.normalizeProperties(Utils.getGeneratedResource(compilation, "some/pkg/Stuff.stapler")));
     }
@@ -46,7 +46,7 @@ public class ConstructorProcessorTest {
                 addLine("}");
         compilation.addSource("some.pkg.package-info").
                 addLine("package some.pkg;");
-        compilation.doCompile(null, "-source", "6");
+        compilation.doCompile(null, "-source", "8", "-Xlint:none");
         assertEquals(Collections.emptyList(), compilation.getDiagnostics());
         assertEquals("{constructor=count,name}", Utils.normalizeProperties(Utils.getGeneratedResource(compilation, "some/pkg/Stuff.stapler")));
     }
@@ -59,7 +59,7 @@ public class ConstructorProcessorTest {
                 addLine("public class Stuff {").
                 addLine("  @DataBoundConstructor Stuff() {}").
                 addLine("}");
-        compilation.doCompile(null, "-source", "6");
+        compilation.doCompile(null, "-source", "8", "-Xlint:none");
         List<Diagnostic<? extends JavaFileObject>> diagnostics = compilation.getDiagnostics();
         assertEquals(1, diagnostics.size());
         String msg = diagnostics.get(0).getMessage(Locale.ENGLISH);
@@ -74,7 +74,7 @@ public class ConstructorProcessorTest {
                 addLine("public abstract class Stuff {").
                 addLine("  @DataBoundConstructor public Stuff() {}").
                 addLine("}");
-        compilation.doCompile(null, "-source", "6");
+        compilation.doCompile(null, "-source", "8", "-Xlint:none");
         List<Diagnostic<? extends JavaFileObject>> diagnostics = compilation.getDiagnostics();
         assertEquals(1, diagnostics.size());
         String msg = diagnostics.get(0).getMessage(Locale.ENGLISH);
@@ -91,7 +91,7 @@ public class ConstructorProcessorTest {
                 addLine("  @DataBoundConstructor public Stuff() {}").
                 addLine("  @DataBoundConstructor public Stuff(int i) {}").
                 addLine("}");
-        compilation.doCompile(null, "-source", "6");
+        compilation.doCompile(null, "-source", "8", "-Xlint:none");
         List<Diagnostic<? extends JavaFileObject>> diagnostics = compilation.getDiagnostics();
         assertEquals(1, diagnostics.size());
         String msg = diagnostics.get(0).getMessage(Locale.ENGLISH);
@@ -111,7 +111,7 @@ public class ConstructorProcessorTest {
                 addLine("   **/").
                 addLine("  public Stuff(int i) {}").
                 addLine("}");
-        compilation.doCompile(null, "-source", "6");
+        compilation.doCompile(null, "-source", "8", "-Xlint:none");
         List<Diagnostic<? extends JavaFileObject>> diagnostics = compilation.getDiagnostics();
         assertEquals(1, diagnostics.size());
         String msg = diagnostics.get(0).getMessage(Locale.ENGLISH);
@@ -128,7 +128,7 @@ public class ConstructorProcessorTest {
                 addLine("  @DataBoundConstructor public Stuff() {}").
                 addLine("  public Stuff(int i) {}").
                 addLine("}");
-        compilation.doCompile(null, "-source", "6");
+        compilation.doCompile(null, "-source", "8", "-Xlint:none");
         List<Diagnostic<? extends JavaFileObject>> diagnostics = compilation.getDiagnostics();
         assertEquals(0, diagnostics.size());
     }

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/ExportedBeanAnnotationProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/ExportedBeanAnnotationProcessorTest.java
@@ -25,7 +25,7 @@ public class ExportedBeanAnnotationProcessorTest {
                 addLine("  /** This gets the display name. */").
                 addLine("  @Exported(name=\"name\") public String getDisplayName() {return null;}").
                 addLine("}");
-        compilation.doCompile(null, "-source", "6");
+        compilation.doCompile(null, "-source", "8", "-Xlint:none");
         assertEquals(Collections.emptyList(), compilation.getDiagnostics());
         assertEqualsCRLF("some.pkg.Stuff\n", Utils.getGeneratedResource(compilation, "META-INF/services/annotations/org.kohsuke.stapler.export.ExportedBean"));
         assertEqualsCRLF("some.pkg.Stuff\n", Utils.getGeneratedResource(compilation, ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
@@ -40,7 +40,7 @@ public class ExportedBeanAnnotationProcessorTest {
                 addLine("@ExportedBean public class Stuff {").
                 addLine("  @Exported public int getCount() {return 0;}").
                 addLine("}");
-        compilation.doCompile(null, "-source", "6");
+        compilation.doCompile(null, "-source", "8", "-Xlint:none");
         assertEquals(Collections.emptyList(), compilation.getDiagnostics());
         assertEqualsCRLF("some.pkg.Stuff\n", Utils.getGeneratedResource(compilation, "META-INF/services/annotations/org.kohsuke.stapler.export.ExportedBean"));
         assertEqualsCRLF("some.pkg.Stuff\n", Utils.getGeneratedResource(compilation, ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
@@ -59,7 +59,7 @@ public class ExportedBeanAnnotationProcessorTest {
                 addLine("public class Stuff extends " + Super.class.getCanonicalName() + " {").
                 addLine("  @Override public int getCount() {return 0;}").
                 addLine("}");
-        compilation.doCompile(null, "-source", "6");
+        compilation.doCompile(null, "-source", "8", "-Xlint:none");
         assertEquals(Collections.emptyList(), compilation.getDiagnostics());
         /* #7188605: broken in JDK 6u33 + org.jvnet.hudson:annotation-indexer:1.2:
         assertEquals("some.pkg.Stuff\n", Utils.getGeneratedResource(compilation, "META-INF/services/annotations/org.kohsuke.stapler.export.ExportedBean"));
@@ -78,7 +78,7 @@ public class ExportedBeanAnnotationProcessorTest {
                 addLine("@ExportedBean public class Stuff {").
                 addLine("  @Exported public int getCount() {return 0;}").
                 addLine("}");
-        compilation.doCompile(null, "-source", "6");
+        compilation.doCompile(null, "-source", "8", "-Xlint:none");
         assertEquals(Collections.emptyList(), compilation.getDiagnostics());
         assertEqualsCRLF("some.pkg.Stuff\n", Utils.getGeneratedResource(compilation, ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
         compilation = new Compilation(compilation);
@@ -88,7 +88,7 @@ public class ExportedBeanAnnotationProcessorTest {
                 addLine("@ExportedBean public class MoreStuff {").
                 addLine("  @Exported public int getCount() {return 0;}").
                 addLine("}");
-        compilation.doCompile(null, "-source", "6");
+        compilation.doCompile(null, "-source", "8", "-Xlint:none");
         assertEquals(Collections.emptyList(), compilation.getDiagnostics());
         assertEqualsCRLF("some.pkg.MoreStuff\nsome.pkg.Stuff\n", Utils.getGeneratedResource(compilation, ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
     }

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/QueryParameterAnnotationProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/QueryParameterAnnotationProcessorTest.java
@@ -18,7 +18,7 @@ public class QueryParameterAnnotationProcessorTest {
                 addLine("  public void doOneThing(@QueryParameter String key) {}").
                 addLine("  public void doAnother(@QueryParameter(\"ignoredHere\") String name, @QueryParameter String address) {}").
                 addLine("}");
-        compilation.doCompile(null, "-source", "6");
+        compilation.doCompile(null, "-source", "8", "-Xlint:none");
         assertEquals(Collections.emptyList(), compilation.getDiagnostics());
         assertEquals("key", Utils.getGeneratedResource(compilation, "some/pkg/Stuff/doOneThing.stapler"));
         assertEquals("name,address", Utils.getGeneratedResource(compilation, "some/pkg/Stuff/doAnother.stapler"));

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/SourceGeneratingAnnotationProcessor.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/SourceGeneratingAnnotationProcessor.java
@@ -41,7 +41,7 @@ import javax.tools.Diagnostic;
 import javax.tools.JavaFileObject;
 import org.kohsuke.MetaInfServices;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @SupportedAnnotationTypes("org.kohsuke.stapler.jsr269.SourceGeneratingAnnotation")
 @MetaInfServices(Processor.class)
 public class SourceGeneratingAnnotationProcessor extends AbstractProcessor {


### PR DESCRIPTION
Some tests were still using Java 6. This updates them to use Java 8. The addition of `-Xlint:none` is because otherwise the tests fail with erors like "warning: Supported source version `RELEASE_6` from annotation processor `net.java.dev.hickory.prism.internal.PrismGenerator` less than `-source 1.8`". Fixing this would require patching `PrismGenerator`, which doesn't even exist on GItHub (much less with any activity in the past decade), or finding some other library or method of testing annotation processors, both of which are a bit more effort than I'm willing to put in at the moment, so silencing the linter warnings in the tests seemed like the easiest choice.