### PR TITLE
Use `@code` rather than `<tt>`

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/AcceptHeader.java
+++ b/core/src/main/java/org/kohsuke/stapler/AcceptHeader.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Represents the <tt>Accept</tt> HTTP header and help server choose the right media type to serve.
+ * Represents the {@code Accept} HTTP header and help server choose the right media type to serve.
  *
  * <p>
  * Typical usage:

--- a/core/src/main/java/org/kohsuke/stapler/Ancestor.java
+++ b/core/src/main/java/org/kohsuke/stapler/Ancestor.java
@@ -45,8 +45,8 @@ public interface Ancestor {
      * {@link HttpServletRequest#getContextPath() context path},
      * and it ends without '/'. So, for example, if your web app
      * is deployed as "mywebapp" and this ancestor object is
-     * obtained from the app root object by <tt>getFoo().getBar(3)</tt>,
-     * then this string will be <tt>/mywebapp/foo/bar/3</tt>
+     * obtained from the app root object by {@code getFoo().getBar(3)},
+     * then this string will be {@code /mywebapp/foo/bar/3}
      *
      * <p>
      * Any ASCII-unsafe characters are escaped.
@@ -63,8 +63,8 @@ public interface Ancestor {
      * The returned string represents the portion of the request URL
      * that follows this ancestor. It starts and ends without '/'.
      * So, for example, if the request URL is "foo/bar/3" and this ancestor object is
-     * obtained from the app root object by <tt>getFoo()</tt>,
-     * then this string will be <tt>bar/3</tt>
+     * obtained from the app root object by {@code getFoo()},
+     * then this string will be {@code bar/3}
      */
     String getRestOfUrl();
 

--- a/core/src/main/java/org/kohsuke/stapler/DataBoundSetter.java
+++ b/core/src/main/java/org/kohsuke/stapler/DataBoundSetter.java
@@ -23,7 +23,7 @@ import static java.lang.annotation.RetentionPolicy.*;
  *
  * <p>
  * The setter method is discovered through {@link Introspector}, so setter method name must match
- * the property name (such as <tt>setFoo</tt> for the <tt>foo</tt> property), and it needs to be public.
+ * the property name (such as {@code setFoo} for the {@code foo} property), and it needs to be public.
  *
  * <p>
  * The field is discovered through simple reflection, so its name must match the property name, but

--- a/core/src/main/java/org/kohsuke/stapler/HttpResponse.java
+++ b/core/src/main/java/org/kohsuke/stapler/HttpResponse.java
@@ -30,11 +30,11 @@ import java.io.IOException;
  * Object that represents the HTTP response, which is defined as a capability to produce the response.
  *
  * <p>
- * <tt>doXyz(...)</tt> method could return an object of this type or throw an exception of this type, and if it does so,
+ * {@code doXyz(...)} method could return an object of this type or throw an exception of this type, and if it does so,
  * the object is asked to produce HTTP response.
  *
  * <p>
- * This is useful to make <tt>doXyz</tt> look like a real function, and decouple it further from HTTP.
+ * This is useful to make {@code doXyz} look like a real function, and decouple it further from HTTP.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/org/kohsuke/stapler/MetaClass.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClass.java
@@ -75,7 +75,7 @@ public class MetaClass extends TearOffSupport {
 
     /**
      * Base metaclass.
-     * Note that <tt>baseClass.clazz==clazz.getSuperClass()</tt>
+     * Note that {@code baseClass.clazz==clazz.getSuperClass()}
      */
     public final MetaClass baseClass;
 

--- a/core/src/main/java/org/kohsuke/stapler/Stapler.java
+++ b/core/src/main/java/org/kohsuke/stapler/Stapler.java
@@ -338,7 +338,7 @@ public class Stapler extends HttpServlet {
          *
          * <p>
          * The syntax of the locale specific resource is the same as property file localization.
-         * So Japanese resource for <tt>foo.html</tt> would be named <tt>foo_ja.html</tt>.
+         * So Japanese resource for {@code foo.html} would be named {@code foo_ja.html}.
          *
          * @param path
          *      path/URL-like string that represents the path of the base resource,

--- a/core/src/main/java/org/kohsuke/stapler/StaplerRequest.java
+++ b/core/src/main/java/org/kohsuke/stapler/StaplerRequest.java
@@ -67,7 +67,7 @@ public interface StaplerRequest extends HttpServletRequest {
      *
      * <p>
      * For example, if the requested URL is "foo/bar/zot/abc?def=ghi" and
-     * "foo/bar" portion matched <tt>bar.jsp</tt>, this method returns
+     * "foo/bar" portion matched {@code bar.jsp}, this method returns
      * "/zot/abc".
      *
      * <p>
@@ -115,7 +115,7 @@ public interface StaplerRequest extends HttpServletRequest {
      *      <p>
      *      For Jelly, this also accepts absolute path name that starts
      *      with '/', such as "/foo/bar/zot.jelly". In this case,
-     *      <tt>it.getClass().getClassLoader()</tt> is searched for this script. 
+     *      {@code it.getClass().getClassLoader()} is searched for this script. 
      *
      * @return null
      *      if neither JSP nor Jelly is not found by the given name.
@@ -141,7 +141,7 @@ public interface StaplerRequest extends HttpServletRequest {
 
     /**
      * Gets the part of the request URL from protocol up to the context path.
-     * So typically it's something like <tt>http://foobar:8080/something</tt>
+     * So typically it's something like {@code http://foobar:8080/something}
      */
     String getRootPath();
 
@@ -210,15 +210,15 @@ public interface StaplerRequest extends HttpServletRequest {
      * This method can behave in three ways.
      *
      * <ol>
-     *  <li>If <tt>timestampOfResource</tt> is 0 or negative,
+     *  <li>If {@code timestampOfResource} is 0 or negative,
      *      this method just returns false.
      *
      *  <li>If "If-Modified-Since" header is sent and if it's bigger than
-     *      <tt>timestampOfResource</tt>, then this method sets
+     *      {@code timestampOfResource}, then this method sets
      *      {@link HttpServletResponse#SC_NOT_MODIFIED} as the response code
      *      and returns true.
      *
-     *  <li>Otherwise, "Last-Modified" header is added with <tt>timestampOfResource</tt> value,
+     *  <li>Otherwise, "Last-Modified" header is added with {@code timestampOfResource} value,
      *      and this method returns false.
      * </ol>
      *
@@ -265,7 +265,7 @@ public interface StaplerRequest extends HttpServletRequest {
      * Binds form parameters to a bean by using introspection.
      *
      * For example, if there's a parameter called 'foo' that has value 'abc',
-     * then <tt>bean.setFoo('abc')</tt> will be invoked. This will be repeated
+     * then {@code bean.setFoo('abc')} will be invoked. This will be repeated
      * for all parameters. Parameters that do not have corresponding setters will
      * be simply ignored.
      *
@@ -288,7 +288,7 @@ public interface StaplerRequest extends HttpServletRequest {
      * property name after the prefix is used.
      *
      * So for example, if the prefix is "foo.", then property name "foo.bar" with value
-     * "zot" will invoke <tt>bean.setBar("zot")</tt>.
+     * "zot" will invoke {@code bean.setBar("zot")}.
      *
      *
      * @deprecated
@@ -309,8 +309,8 @@ public interface StaplerRequest extends HttpServletRequest {
      * fill in multiple beans.
      *
      * <p>
-     * For example, if <tt>getParameterValues("foo")=={"abc","def"}</tt>
-     * and <tt>getParameterValues("bar")=={"5","3"}</tt>, then this method will
+     * For example, if {@code getParameterValues("foo")=={"abc","def"}}
+     * and {@code getParameterValues("bar")=={"5","3"}}, then this method will
      * return two objects (the first with "abc" and "5", the second with
      * "def" and "3".)
      *
@@ -400,7 +400,7 @@ public interface StaplerRequest extends HttpServletRequest {
      *
      * <h3>Sub-typing</h3>
      * <p>
-     * In the above example, a new instance of <tt>Bar</tt> was created,
+     * In the above example, a new instance of {@code Bar} was created,
      * but you can also create a subtype of Bar by having the '$class' property in
      * JSON like this:
      *
@@ -414,7 +414,7 @@ public interface StaplerRequest extends HttpServletRequest {
      * </pre>
      *
      * <p>
-     * The type that shows up in the constructor (<tt>Bar</tt> in this case)
+     * The type that shows up in the constructor ({@code Bar} in this case)
      * can be an interface or an abstract class.
      */
     <T>

--- a/core/src/main/java/org/kohsuke/stapler/StaplerResponse.java
+++ b/core/src/main/java/org/kohsuke/stapler/StaplerResponse.java
@@ -97,7 +97,7 @@ public interface StaplerResponse extends HttpServletResponse {
      * Works like {@link #serveFile(StaplerRequest, URL)} but chooses the locale specific
      * version of the resource if it's available. The convention of "locale specific version"
      * is the same as that of property files.
-     * So Japanese resource for <tt>foo.html</tt> would be named <tt>foo_ja.html</tt>.
+     * So Japanese resource for {@code foo.html} would be named {@code foo_ja.html}.
      */
     void serveLocalizedFile(StaplerRequest request, URL res) throws ServletException, IOException;
 

--- a/core/src/main/java/org/kohsuke/stapler/WebMethod.java
+++ b/core/src/main/java/org/kohsuke/stapler/WebMethod.java
@@ -48,7 +48,7 @@ public @interface WebMethod {
      * URL names assigned to this method.
      *
      * <p>
-     * Normally, for <tt>doXyz</tt> method, the name is <tt>xyz</tt>,
+     * Normally, for {@code doXyz} method, the name is {@code xyz},
      * but you can use this to assign multiple names or non-default names.
      * Often useful for using names that contain non-identifier characters.
      */

--- a/core/src/main/java/org/kohsuke/stapler/config/ConfigurationLoader.java
+++ b/core/src/main/java/org/kohsuke/stapler/config/ConfigurationLoader.java
@@ -27,7 +27,7 @@ import static org.kohsuke.stapler.config.Configuration.UNSPECIFIED;
  *
  * <p>
  * Typical usage would be {@code MyConfig config=ConfigurationLoad.from(...).as(MyConfig.class)}
- * where the <tt>MyConfig</tt> interface defines a bunch of methods named after
+ * where the {@code MyConfig} interface defines a bunch of methods named after
  * the property name:
  *
  * <pre>

--- a/core/src/main/java/org/kohsuke/stapler/export/CustomExportedBean.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/CustomExportedBean.java
@@ -25,7 +25,7 @@ package org.kohsuke.stapler.export;
 
 /**
  * Interface that an exposed bean can implement, to do the equivalent
- * of <tt>writeReplace</tt> in Java serialization.
+ * of {@code writeReplace} in Java serialization.
  * @author Kohsuke Kawaguchi
  */
 public interface CustomExportedBean {

--- a/core/src/main/java/org/kohsuke/stapler/export/PythonDataWriter.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/PythonDataWriter.java
@@ -27,11 +27,11 @@ import java.io.Writer;
 import java.io.IOException;
 
 /**
- * Writes out the format that can be <tt>eval</tt>-ed from Python.
+ * Writes out the format that can be {@code eval}-ed from Python.
  *
  * <p>
  * Python uses the same list and map literal syntax as JavaScript.
- * The only difference is <tt>null</tt> vs <tt>None</tt>.
+ * The only difference is {@code null} vs {@code None}.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/org/kohsuke/stapler/export/RubyDataWriter.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/RubyDataWriter.java
@@ -27,12 +27,12 @@ import java.io.IOException;
 import java.io.Writer;
 
 /**
- * Writes out the format that can be <tt>eval</tt>-ed from Ruby.
+ * Writes out the format that can be {@code eval}-ed from Ruby.
  *
  * <p>
  * Ruby uses a similar list and map literal syntax as JavaScript.
- * The only differences are <tt>null</tt> vs <tt>nil</tt> and
- * <tt>key:value</tt> vs <tt>key => value</tt>.
+ * The only differences are {@code null} vs {@code nil} and
+ * {@code key:value} vs {@code key => value}.
  *
  * @author Kohsuke Kawaguchi, Jim Meyer
  */

--- a/core/src/main/java/org/kohsuke/stapler/export/TypeUtil.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/TypeUtil.java
@@ -460,10 +460,10 @@ public class TypeUtil {
         }
 
         /**
-         * Returns  a <tt>Type</tt> object representing the component type
+         * Returns  a {@code Type} object representing the component type
          * of this array.
          *
-         * @return a <tt>Type</tt> object representing the component type
+         * @return a {@code Type} object representing the component type
          *         of this array
          * @since 1.5
          */

--- a/core/src/main/java/org/kohsuke/stapler/framework/errors/NoHomeDirError.java
+++ b/core/src/main/java/org/kohsuke/stapler/framework/errors/NoHomeDirError.java
@@ -30,7 +30,7 @@ import java.io.File;
  * we couldn't create the home directory.
  *
  * <p>
- * <tt>index.jelly</tt> would display a nice friendly error page.
+ * {@code index.jelly} would display a nice friendly error page.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/org/kohsuke/stapler/framework/io/LineEndNormalizingWriter.java
+++ b/core/src/main/java/org/kohsuke/stapler/framework/io/LineEndNormalizingWriter.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * Finds the lone LF and converts that to CR+LF.
  *
  * <p>
- * Internet Explorer's <tt>XmlHttpRequest.responseText</tt> seems to
+ * Internet Explorer's {@code XmlHttpRequest.responseText} seems to
  * normalize the line end, and if we only send LF without CR, it will
  * not recognize that as a new line. To work around this problem,
  * we use this filter to always convert LF to CR+LF.

--- a/core/src/main/java/org/kohsuke/stapler/json/JsonBody.java
+++ b/core/src/main/java/org/kohsuke/stapler/json/JsonBody.java
@@ -20,7 +20,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Binds the body payload into POJO via json-lib.
  *
  * <p>
- * On a web-bound <tt>doXyz</tt> method, use this method on a parameter to get the content of the request
+ * On a web-bound {@code doXyz} method, use this method on a parameter to get the content of the request
  * data-bound to a bean through {@link JSONObject#fromObject(Object)} and inject it as a parameter.
  * For example,
  *

--- a/core/src/main/java/org/kohsuke/stapler/json/SubmittedForm.java
+++ b/core/src/main/java/org/kohsuke/stapler/json/SubmittedForm.java
@@ -18,7 +18,7 @@ import static java.lang.annotation.RetentionPolicy.*;
  * Binds {@linkplain StaplerRequest#getSubmittedForm() the submitted form} to a parameter of a web-bound method.
  *
  * <p>
- * On a web-bound <tt>doXyz</tt> method, use this annotation on a parameter to get the submitted
+ * On a web-bound {@code doXyz} method, use this annotation on a parameter to get the submitted
  * structured form content and inject it as {@link JSONObject}.
  * For example,
  *

--- a/jelly/src/main/java/org/kohsuke/stapler/framework/adjunct/AdjunctManager.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/framework/adjunct/AdjunctManager.java
@@ -61,7 +61,7 @@ import java.util.concurrent.ConcurrentSkipListSet;
  * <pre>{@code adjunct "org.kohsuke.stapler.bootstrap"}</pre>
  *
  * <p>
- * ... and this produces a series of <tt>style</tt> and <tt>script</tt> tags that include all the
+ * ... and this produces a series of {@code style} and {@code script} tags that include all the
  * necessary JavaScript, CSS, and their dependencies.
  *
  * <p>

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyClassTearOff.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyClassTearOff.java
@@ -96,7 +96,7 @@ public class JellyClassTearOff extends AbstractTearOff<JellyClassLoaderTearOff,S
     }
 
     /**
-     * Serves <tt>index.jelly</tt> if it's available, and returns true.
+     * Serves {@code index.jelly} if it's available, and returns true.
      */
     @Deprecated
     public boolean serveIndexJelly(StaplerRequest req, StaplerResponse rsp, Object node) throws ServletException, IOException {

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/ResourceBundle.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/ResourceBundle.java
@@ -46,7 +46,7 @@ public class ResourceBundle {
     /**
      * URL to load message resources from, except the ".properties" suffix.
      * <p>
-     * This is normally something like <tt>file://path/to/somewhere/org/acme/Foo</tt>.
+     * This is normally something like {@code file://path/to/somewhere/org/acme/Foo}.
      */
     private final String baseName;
 

--- a/jsp/src/main/java/org/kohsuke/stapler/tags/Include.java
+++ b/jsp/src/main/java/org/kohsuke/stapler/tags/Include.java
@@ -47,7 +47,7 @@ import java.io.PrintWriter;
  * and includes the contents of it, just like {@code <jsp:include>}.
  *
  * <p>
- * For example, if the "it" object is an instance of the <tt>Foo</tt> class,
+ * For example, if the "it" object is an instance of the {@code Foo} class,
  * which looks like the following:
  *
  * <pre>{@code


### PR DESCRIPTION
Without this, building with Java 11 fails with "error: tag not supported in the generated HTML version: tt" for whatever reason.