### PR TITLE
Adopt POM Code Convention

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,25 +6,10 @@
     <artifactId>stapler-parent</artifactId>
     <version>${changelist}</version>
   </parent>
-  
+
   <artifactId>stapler</artifactId>
   <name>Stapler</name>
   <description>Stapler HTTP request handling engine</description>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
   <dependencies>
     <dependency>
       <groupId>javax.annotation</groupId>
@@ -99,7 +84,7 @@
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
       <version>1.4</version>
-    </dependency>    
+    </dependency>
     <!-- optional REST support -->
     <dependency>
       <groupId>com.sun.xml.txw2</groupId>
@@ -181,5 +166,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-</project>
 
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -6,11 +6,11 @@
     <artifactId>stapler-parent</artifactId>
     <version>${changelist}</version>
   </parent>
-  
+
   <artifactId>stapler-groovy</artifactId>
   <name>Stapler Groovy module</name>
   <description>Groovy binding for Stapler</description>
-  
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -53,4 +53,3 @@
     </dependency>
   </dependencies>
 </project>
-

--- a/jelly/pom.xml
+++ b/jelly/pom.xml
@@ -42,7 +42,8 @@
       <artifactId>dom4j</artifactId>
       <version>2.1.3</version>
     </dependency>
-    <dependency><!-- only needed for annotations, hence optional -->
+    <dependency>
+      <!-- only needed for annotations, hence optional -->
       <groupId>org.jvnet.maven-jellydoc-plugin</groupId>
       <artifactId>jellydoc-annotations</artifactId>
       <version>1.5</version>
@@ -151,13 +152,6 @@
           <plugin>
             <groupId>org.jvnet.maven-jellydoc-plugin</groupId>
             <artifactId>maven-jellydoc-plugin</artifactId>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>jellydoc</goal>
-                </goals>
-              </execution>
-            </executions>
             <dependencies>
               <dependency>
                 <groupId>com.github.olivergondza</groupId>
@@ -165,6 +159,13 @@
                 <version>0.1</version>
               </dependency>
             </dependencies>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>jellydoc</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>
@@ -181,4 +182,3 @@
     </profile>
   </profiles>
 </project>
-

--- a/jrebel/pom.xml
+++ b/jrebel/pom.xml
@@ -6,11 +6,11 @@
     <artifactId>stapler-parent</artifactId>
     <version>${changelist}</version>
   </parent>
-  
+
   <artifactId>stapler-jrebel</artifactId>
   <name>Stapler JRebel module</name>
   <description>JRebel reloading support for Stapler</description>
-  
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/jsp/pom.xml
+++ b/jsp/pom.xml
@@ -6,11 +6,11 @@
     <artifactId>stapler-parent</artifactId>
     <version>${changelist}</version>
   </parent>
-  
+
   <artifactId>stapler-jsp</artifactId>
   <name>Stapler JSP module</name>
   <description>JSP binding for Stapler</description>
-  
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -36,4 +36,3 @@
     </dependency>
   </dependencies>
 </project>
-

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
@@ -10,12 +10,22 @@
   </parent>
   <groupId>org.kohsuke.stapler</groupId>
   <artifactId>stapler-parent</artifactId>
-  <packaging>pom</packaging>
   <version>${changelist}</version>
+  <packaging>pom</packaging>
 
   <name>Stapler</name>
   <description>Stapler HTTP request handling engine</description>
-  
+
+  <url>https://github.com/jenkinsci/stapler</url>
+
+  <licenses>
+    <license>
+      <name>2-clause BSD license</name>
+      <url>https://opensource.org/licenses/BSD-2-Clause</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <modules>
     <module>core</module>
     <module>jsp</module>
@@ -24,22 +34,95 @@
     <module>jrebel</module>
   </modules>
 
-  <url>https://github.com/jenkinsci/stapler</url>
-
-  <licenses>
-    <license>
-      <name>2-clause BSD license</name>
-      <distribution>repo</distribution>
-      <url>https://opensource.org/licenses/BSD-2-Clause</url>
-    </license>
-  </licenses>
-  
   <scm>
     <connection>scm:git:https://github.com/jenkinsci/stapler.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/stapler.git</developerConnection>
-    <url>https://github.com/jenkinsci/stapler</url>
     <tag>${scmTag}</tag>
+    <url>https://github.com/jenkinsci/stapler</url>
   </scm>
+
+  <properties>
+    <changelist>999999-SNAPSHOT</changelist>
+    <scmTag>HEAD</scmTag>
+    <spotbugs.excludeFilterFile>${project.basedir}/../src/spotbugs/spotbugs-excludes.xml</spotbugs.excludeFilterFile>
+    <jetty.version>9.4.44.v20210927</jetty.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>commons-logging</groupId>
+        <artifactId>commons-logging</artifactId>
+        <version>1.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kohsuke.metainf-services</groupId>
+        <artifactId>metainf-services</artifactId>
+        <version>1.8</version>
+      </dependency>
+
+      <!-- test dependencies -->
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-server</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-util</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-servlet</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-webapp</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>4.2.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.main</groupId>
+        <artifactId>jenkins-test-harness-htmlunit</artifactId>
+        <version>66.v712ea44bccba</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jvnet.hudson</groupId>
+        <artifactId>commons-jelly-tags-define</artifactId>
+        <version>1.0.1-hudson-20071021</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest</artifactId>
+        <version>2.2</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-collections</groupId>
+        <artifactId>commons-collections</artifactId>
+        <version>3.2.2</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
 
   <repositories>
     <repository>
@@ -54,13 +137,6 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-
-  <properties>
-    <changelist>999999-SNAPSHOT</changelist>
-    <scmTag>HEAD</scmTag>
-    <spotbugs.excludeFilterFile>${project.basedir}/../src/spotbugs/spotbugs-excludes.xml</spotbugs.excludeFilterFile>
-    <jetty.version>9.4.44.v20210927</jetty.version>
-  </properties>
 
   <build>
     <pluginManagement>
@@ -78,80 +154,4 @@
       </plugins>
     </pluginManagement>
   </build>
-
-  <dependencyManagement>
-  <dependencies>
-    <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-      <version>1.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.kohsuke.metainf-services</groupId>
-      <artifactId>metainf-services</artifactId>
-      <version>1.8</version>
-    </dependency>
-
-    <!-- test dependencies -->
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-server</artifactId>
-      <version>${jetty.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-util</artifactId>
-      <version>${jetty.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
-      <version>${jetty.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-webapp</artifactId>
-      <version>${jetty.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>4.2.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-test-harness-htmlunit</artifactId>
-      <version>66.v712ea44bccba</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jvnet.hudson</groupId>
-      <artifactId>commons-jelly-tags-define</artifactId>
-      <version>1.0.1-hudson-20071021</version>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <version>2.2</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-      <version>3.2.2</version>
-    </dependency>
-  </dependencies>
-  </dependencyManagement>
-
-  <dependencies>
-    <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <optional>true</optional>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-  </dependencies>
 </project>


### PR DESCRIPTION
Adopts the [POM Code Convention](https://maven.apache.org/developers/conventions/code.html#pom-code-convention) that was [voted on by Maven developers in 2008](https://lists.apache.org/thread/h8px5t6f3q59cnkzpj1t02wsoynr3ygk). Note that this PR adds no automation; this is just a one-time pass.