### PR TITLE
Dependency cleanup

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -148,6 +148,7 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
+      <version>2.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/jelly/pom.xml
+++ b/jelly/pom.xml
@@ -103,6 +103,7 @@
     <dependency>
       <groupId>org.jvnet.hudson</groupId>
       <artifactId>commons-jelly-tags-define</artifactId>
+      <version>1.0.1-hudson-20071021</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,6 @@
         <version>3.2.2</version>
       </dependency>
       <dependency>
-        <groupId>commons-logging</groupId>
-        <artifactId>commons-logging</artifactId>
-        <version>1.2</version>
-      </dependency>
-      <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
         <version>${jetty.version}</version>
@@ -81,19 +76,9 @@
         <version>${jetty.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest</artifactId>
-        <version>2.2</version>
-      </dependency>
-      <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-test-harness-htmlunit</artifactId>
         <version>66.v712ea44bccba</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jvnet.hudson</groupId>
-        <artifactId>commons-jelly-tags-define</artifactId>
-        <version>1.0.1-hudson-20071021</version>
       </dependency>
       <dependency>
         <groupId>org.kohsuke.metainf-services</groupId>


### PR DESCRIPTION
Now that JRuby support has been dropped, some entries in the main `pom.xml` file's `dependencyManagement` section (which were originally there to apply to multiple modules) are now unneeded and can be moved into the corresponding module. This improves readability by keeping the dependency definition closer to where it is actually used.