### PR TITLE
Bump `annotation-api` from 1.3.2 to 1.3.5

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,9 +50,9 @@
       <version>2.11.0</version>
     </dependency>
     <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>1.3.2</version>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>1.3.5</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>


### PR DESCRIPTION
Version 1.3.5 is the last version prior to the Jakarta package renaming. Thus it is compatible with our existing consumers.