### PR TITLE
Begin migration to Jakarta Annotations

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -49,10 +49,19 @@
       <artifactId>commons-io</artifactId>
       <version>2.11.0</version>
     </dependency>
+    <!--
+      For compatibility only. TODO once plugins have migrated to Jakarta Annotations,
+      this dependency can be dropped.
+    -->
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+    </dependency>
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
-      <version>1.3.5</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/core/src/main/java/org/kohsuke/stapler/DataBoundSetter.java
+++ b/core/src/main/java/org/kohsuke/stapler/DataBoundSetter.java
@@ -1,8 +1,8 @@
 package org.kohsuke.stapler;
 
+import jakarta.annotation.PostConstruct;
 import net.sf.json.JSONObject;
 
-import javax.annotation.PostConstruct;
 import java.beans.Introspector;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;

--- a/core/src/main/java/org/kohsuke/stapler/MetaClass.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClass.java
@@ -24,6 +24,7 @@
 package org.kohsuke.stapler;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import jakarta.annotation.PostConstruct;
 import net.sf.json.JSONArray;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
@@ -31,7 +32,6 @@ import org.kohsuke.stapler.lang.FieldRef;
 import org.kohsuke.stapler.lang.Klass;
 import org.kohsuke.stapler.lang.MethodRef;
 
-import javax.annotation.PostConstruct;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -601,7 +601,7 @@ public class MetaClass extends TearOffSupport {
             SingleLinkedList<MethodRef> l = baseClass==null ? SingleLinkedList.empty() : baseClass.getPostConstructMethods();
 
             for (MethodRef mr : klass.getDeclaredMethods()) {
-                if (mr.hasAnnotation(PostConstruct.class)) {
+                if (mr.hasAnnotation(PostConstruct.class) || mr.hasAnnotation(javax.annotation.PostConstruct.class)) {
                     l = l.grow(mr);
                 }
             }

--- a/core/src/main/java/org/kohsuke/stapler/framework/io/WriterOutputStream.java
+++ b/core/src/main/java/org/kohsuke/stapler/framework/io/WriterOutputStream.java
@@ -87,7 +87,8 @@ public class WriterOutputStream extends OutputStream {
 
     private void flushOutput() throws IOException {
         writer.write(out.array(),0,out.position());
-        out.clear();
+        // Downcasting to Buffer is needed to avoid NoSuchMethodError errors because Java 11 uses covariance in the ByteBuffer return type.
+        ((Buffer) out).clear();
     }
 
     @Override
@@ -96,7 +97,8 @@ public class WriterOutputStream extends OutputStream {
         flushOutput();
         writer.close();
 
-        buf.rewind();
+        // Downcasting to Buffer is needed to avoid NoSuchMethodError errors because Java 11 uses covariance in the ByteBuffer return type.
+        ((Buffer) buf).rewind();
     }
 
     /**
@@ -111,7 +113,8 @@ public class WriterOutputStream extends OutputStream {
      *      if true, tell the decoder that all the input bytes are ready.
      */
     private void decode(boolean last) throws IOException {
-        buf.flip();
+        // Downcasting to Buffer is needed to avoid NoSuchMethodError errors because Java 11 uses covariance in the ByteBuffer return type.
+        ((Buffer) buf).flip();
         while(true) {
             CoderResult r = decoder.decode(buf, out, last);
             if(r==CoderResult.OVERFLOW) {

--- a/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
@@ -1,10 +1,10 @@
 package org.kohsuke.stapler;
 
+import jakarta.annotation.PostConstruct;
 import junit.framework.TestCase;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
-import javax.annotation.PostConstruct;
 import java.lang.reflect.Type;
 import java.net.Proxy;
 import java.util.ArrayList;


### PR DESCRIPTION
### Problem

Core ships the Java EE annotation API, which is consumed both in core itself and in Stapler (a core dependency). Specifically, we consume `javax.annotation.PostConstruct`. `configuration-as-code`, `coverity`, `datetime-constraint`, `opentelemetry`, and `strict-crumb-issuer` consume `javax.annotation.PostConstruct` from core. `coverity`, `jira`, and `opentelemetry` consume `javax.annotation.PreDestroy` from core. `gitlab-plugin` consumes `javax.annotation.Priority` from core. All of these are subject to Jakarta package renames. This means we need to come up with a migration plan.

### Solution

This PR begins a migration by shipping both the old `javax.annotation` classes and the new `jakarta.annotation` classes, adjusting Stapler to check both `jakarta.annotation.PostConstruct` and `javax.annotation.PostConstruct` for backward compatibility. Stapler itself is migrated to `jakarta.annotation`, and when this PR is merged and released and core upgrades to it, then core can also switch to `jakarta.annotation`. This just leaves the plugins mentioned above. As each plugin upgrades its core baseline to one that includes a Stapler release with this PR, the plugin can migrate from `javax.annotation` to `jakarta.annotation`. Once each of the above plugins has done so and the PRs have been merged and released, `usage-in-plugins` should show no usages for `javax.annotation` in the ecosystem. At that point, the `javax.annotation:javax.annotation-api` dependency can be removed and the migration will be considered complete.