### PR TITLE
Remove usages of `StringUtils#join`

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/Function.java
+++ b/core/src/main/java/org/kohsuke/stapler/Function.java
@@ -23,7 +23,6 @@
 
 package org.kohsuke.stapler;
 
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.interceptor.Interceptor;
 import org.kohsuke.stapler.interceptor.InterceptorAnnotation;
 
@@ -44,6 +43,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.kohsuke.stapler.ReflectionUtils.*;
 
@@ -328,9 +328,9 @@ public abstract class Function {
         @Override
         public String getSignature() {
             String prefix = isStatic() ? "staticMethod" : "method";
-            String value = StringUtils.join(Arrays.asList(prefix, m.getDeclaringClass().getName(), getName()), ' ');
+            String value = Stream.of(prefix, m.getDeclaringClass().getName(), getName()).collect(Collectors.joining(" "));
             if (getParameterTypes().length > 0) {
-                value += " " + StringUtils.join(Arrays.stream(getParameterTypes()).map(Class::getName).collect(Collectors.toList()), ' ');
+                value += " " + Stream.of(getParameterTypes()).map(Class::getName).collect(Collectors.joining(" "));
             }
             return value;
         }

--- a/core/src/main/java/org/kohsuke/stapler/StaticViewFacet.java
+++ b/core/src/main/java/org/kohsuke/stapler/StaticViewFacet.java
@@ -1,6 +1,5 @@
 package org.kohsuke.stapler;
 
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.lang.Klass;
 
 import javax.servlet.RequestDispatcher;
@@ -70,7 +69,7 @@ public class StaticViewFacet extends Facet {
 
             @Override
             public String toString() {
-                return "static file for url=/VIEW"+StringUtils.join(allowedExtensions,"|");
+                return "static file for url=/VIEW" + String.join("|", allowedExtensions);
             }
         });
     }

--- a/core/src/main/java/org/kohsuke/stapler/lang/FieldRef.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/FieldRef.java
@@ -1,13 +1,13 @@
 package org.kohsuke.stapler.lang;
 
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.util.IllegalReflectiveAccessLogHandler;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.Arrays;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Fields of {@link Klass}.
@@ -107,7 +107,7 @@ public abstract class FieldRef extends AnnotatedRef {
             @Override
             public String getSignature() {
                 String prefix = isStatic() ? "staticField" : "field";
-                return StringUtils.join(Arrays.asList(prefix, f.getDeclaringClass().getName(), getName()), ' ');
+                return Stream.of(prefix, f.getDeclaringClass().getName(), getName()).collect(Collectors.joining(" "));
             }
 
             @Override


### PR DESCRIPTION
The fewer third-party dependencies we have, the easier maintenance becomes. This PR removes usages of the third-party `StringUtils#join` method in favor of native Java Platform functionality.