### PR TITLE
Slim down `<dependencyManagement>`

### DIFF
--- a/jelly/pom.xml
+++ b/jelly/pom.xml
@@ -11,15 +11,6 @@
   <name>Stapler Jelly module</name>
   <description>Jelly binding for Stapler</description>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>commons-lang</groupId>
-        <artifactId>commons-lang</artifactId>
-        <version>2.6</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,11 +51,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>commons-collections</groupId>
-        <artifactId>commons-collections</artifactId>
-        <version>3.2.2</version>
-      </dependency>
-      <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
         <version>${jetty.version}</version>


### PR DESCRIPTION
As of jenkinsci/jelly#5 and jenkinsci/jelly#14, these are no longer needed. Let's delete them so we don't get bothered by Dependabot updates for them.