### PR TITLE
Clean up SpotBugs exclusions

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/HttpResponses.java
+++ b/core/src/main/java/org/kohsuke/stapler/HttpResponses.java
@@ -24,6 +24,7 @@
 package org.kohsuke.stapler;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -184,6 +185,7 @@ public class HttpResponses {
     /**
      * Redirects the user back to where he came from.
      */
+    @SuppressFBWarnings(value = "MS_EXPOSE_REP", justification = "TODO needs triage")
     public static HttpResponseException forwardToPreviousPage() {
         return FORWARD_TO_PREVIOUS_PAGE;
     }

--- a/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/JellyBuilder.java
+++ b/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/JellyBuilder.java
@@ -553,7 +553,7 @@ public final class JellyBuilder extends GroovyObjectSupport {
      * This method instantiates the class (if not done so already for this request),
      * and return it.
      */
-    @SuppressFBWarnings("REFLC_REFLECTION_MAY_INCREASE_ACCESSIBILITY_OF_CLASS")
+    @SuppressFBWarnings(value = "REFLC_REFLECTION_MAY_INCREASE_ACCESSIBILITY_OF_CLASS", justification = "TODO needs triage")
     public Object taglib(Class type) throws IllegalAccessException, InstantiationException, IOException, SAXException {
         GroovyClosureScript o = taglibs.get(type);
         if(o==null) {

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/IncludeTag.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/IncludeTag.java
@@ -46,7 +46,7 @@ import java.util.logging.Logger;
 public class IncludeTag extends TagSupport {
     public static final Logger LOGGER = Logger.getLogger(IncludeTag.class.getName());
 
-    @SuppressFBWarnings("MS_SHOULD_BE_FINAL")
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "TODO needs triage")
     public static /* non-final for script console */ boolean SKIP_LOGGING_CLASS_SETTER = Boolean.getBoolean(IncludeTag.class.getName() + ".skipLoggingClassSetter");
 
     private Object it;

--- a/src/spotbugs/spotbugs-excludes.xml
+++ b/src/spotbugs/spotbugs-excludes.xml
@@ -1,19 +1,64 @@
 <FindBugsFilter>
+  <!--
+    Exclusions in this section have been triaged and determined to be false positives.
+  -->
   <Match>
-    <!--We don't care about this behavior.-->
-    <Bug pattern="CRLF_INJECTION_LOGS"/>
+    <Or>
+      <!-- We don't care about this behavior -->
+      <Bug pattern="CRLF_INJECTION_LOGS"/>
+      <!-- Jenkins handles this issue differently or doesn't care about it. -->
+      <Bug pattern="INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE"/>
+    </Or>
   </Match>
+  <!--
+    Here lies technical debt. Exclusions in this section have not yet been triaged. When working on
+    on this section, pick an exclusion to triage, then:
+    - If it is a false positive, add a @SuppressFBWarnings(value = "[…]", justification = "[…]")
+      annotation indicating the reason why it is a false positive, then remove the exclusion from
+      this section.
+    - If it is not a false positive, fix the bug, then remove the exclusion from this section.
+   -->
   <Match>
-    <!--Jenkins handles this issue differently or doesn't care about it.-->
-    <Bug pattern="INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE"/>
-  </Match>
-  <Match>
-    <Bug pattern="EI_EXPOSE_REP"/>
-  </Match>
-  <Match>
-    <Bug pattern="EI_EXPOSE_REP2"/>
-  </Match>
-  <Match>
-    <Bug pattern="MS_EXPOSE_REP"/>
+    <Confidence value="2"/>
+    <Or>
+      <And>
+        <Bug pattern="EI_EXPOSE_REP"/>
+        <Or>
+          <Class name="org.kohsuke.stapler.compression.CompressionServletResponse"/>
+          <Class name="org.kohsuke.stapler.framework.AbstractWebAppMain"/>
+          <Class name="org.kohsuke.stapler.jelly.groovy.GroovyClosureScript"/>
+          <Class name="org.kohsuke.stapler.jelly.groovy.GroovyFacet"/>
+          <Class name="org.kohsuke.stapler.jelly.groovy.GroovyServerPageScript"/>
+          <Class name="org.kohsuke.stapler.jelly.groovy.JellyBuilder"/>
+          <Class name="org.kohsuke.stapler.jelly.JellyFacet"/>
+          <Class name="org.kohsuke.stapler.MetaClass"/>
+          <Class name="org.kohsuke.stapler.RequestImpl"/>
+          <Class name="org.kohsuke.stapler.ResponseImpl"/>
+          <Class name="org.kohsuke.stapler.Stapler"/>
+          <Class name="org.kohsuke.stapler.StaplerResponseWrapper"/>
+          <Class name="org.kohsuke.stapler.WebApp"/>
+        </Or>
+      </And>
+      <And>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+        <Or>
+          <Class name="org.kohsuke.stapler.compression.FilterServletOutputStream"/>
+          <Class name="org.kohsuke.stapler.export.SchemaGenerator"/>
+          <Class name="org.kohsuke.stapler.framework.adjunct.AdjunctManager"/>
+          <Class name="org.kohsuke.stapler.framework.io.WriterOutputStream"/>
+          <Class name="org.kohsuke.stapler.interceptor.JsonOutputFilter$FilterPropertyFilter"/>
+          <Class name="org.kohsuke.stapler.jelly.CustomTagLibrary"/>
+          <Class name="org.kohsuke.stapler.jelly.FindAncestorTag"/>
+          <Class name="org.kohsuke.stapler.jelly.groovy.GroovyClassLoaderTearOff"/>
+          <Class name="org.kohsuke.stapler.jelly.groovy.GroovyClosureScript"/>
+          <Class name="org.kohsuke.stapler.jelly.groovy.JellyBuilder"/>
+          <Class name="org.kohsuke.stapler.jelly.JellyClassLoaderTearOff"/>
+          <Class name="org.kohsuke.stapler.json.JsonHttpResponse"/>
+          <Class name="org.kohsuke.stapler.ResponseImpl"/>
+          <Class name="org.kohsuke.stapler.StaplerResponseWrapper"/>
+          <Class name="org.kohsuke.stapler.WebApp"/>
+        </Or>
+      </And>
+    </Or>
   </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Removes no-longer-necessary suppressions, and moves the still-necessary suppressions from `src/spotbugs/spotbugs-excludes.xml` to `@SuppressFBWarnings` annotations in the relevant code (where they are more likely to be noticed and fixed) if there were a reasonable number of them.