### PR TITLE
Fix docs references to html files (use .adoc)

### DIFF
--- a/docs/getting-started.adoc
+++ b/docs/getting-started.adoc
@@ -213,7 +213,7 @@ public void doHello( StaplerRequest request, StaplerResponse response ) {
 
 Hopefully, the basic concept of Stapler is easy to grasp. For the exact
 rules of how URLs are evaluated against your application objects, see
-link:reference.html[the reference guide].
+link:reference.adoc[the reference guide].
 
 If you have any suggestions on how to improve this documentation, please
 create an issue on GitHub.

--- a/docs/reference.adoc
+++ b/docs/reference.adoc
@@ -13,7 +13,7 @@ method.*
 This process can be best understood as a recursively defined
 mathematical function `evaluate(node,url)`. For example,
 link:stapler.png[the hypothetical application] depicted in
-link:what-is.html[the "getting started" document] could have an
+link:what-is.adoc[the "getting started" document] could have an
 evaluation process like the following:
 
 ____


### PR DESCRIPTION
When browsing the documentation on GitHub, the links are broken as they
refer to an HTML document, which has been changed to adoc in commit
ff4f5b4916fbfc8017d1b38298b103a19ed0a987.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue