### PR TITLE
[JENKINS-67911] Stapler does not compile with Java 11

### DIFF
--- a/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/StaplerClosureScript.java
+++ b/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/StaplerClosureScript.java
@@ -27,15 +27,15 @@ public abstract class StaplerClosureScript extends GroovyClosureScript {
      * Looks up the resource bundle with the given key, and returns that string,
      * or otherwise return 'text' as-is.
      */
-    public String _(String text) {
-        return _(text, EMPTY_ARRAY);
+    public String gettext(String text) {
+        return gettext(text, EMPTY_ARRAY);
     }
 
     /**
      * Looks up the resource bundle with the given key, formats with arguments,
      * then return that formatted string.
      */
-    public String _(String key, Object... args) {
+    public String gettext(String key, Object... args) {
 //        JellyBuilder b = (JellyBuilder)getDelegate();
 
         ResourceBundle resourceBundle = getResourceBundle();


### PR DESCRIPTION
### Problem

Compiling Stapler with Java 11 and `<release>11</release>` yields the following results:

```
[ERROR] jenkinsci/stapler/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/StaplerClosureScript.java:[30,18] error: as of release 9, '_' is a keyword, and may not be used as an identifier
[ERROR] jenkinsci/stapler/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/StaplerClosureScript.java:[31,15] error: as of release 9, '_' is a keyword, and may not be used as an identifier
[ERROR] jenkinsci/stapler/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/StaplerClosureScript.java:[38,18] error: as of release 9, '_' is a keyword, and may not be used as an identifier
```

### Solution

Rename the two _ functions as `gettext`, which is a valid Java 9+ identifier.

For backward compatibility with scripts like [this](https://github.com/jenkinsci/jenkins/blob/6f6cca1f8f4a9c535bd822c80cd2ad3cedff9cba/core/src/main/resources/jenkins/model/MasterBuildConfiguration/config.groovy#L5), define `_()` as a metamethod that delegates to `gettext()`.

### Testing done

Set a breakpoint in `gettext()` and verified I could hit it from the Configure System page after this PR just as I could hit the old `_()` break point from that page before this PR.

Also compiled Stapler successfully with Java 11 and `<release>11</release>`.

Fixes #309