### PR TITLE
Add tests for JENKINS-68215

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -156,8 +156,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <version>2.2</version>
+      <artifactId>hamcrest-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -46,6 +46,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/jelly/pom.xml
+++ b/jelly/pom.xml
@@ -87,6 +87,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>version-number</artifactId>
+      <version>1.10</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-test-harness-htmlunit</artifactId>
       <scope>test</scope>

--- a/jelly/src/test/java/org/kohsuke/stapler/jelly/AttributeExpressionTest.java
+++ b/jelly/src/test/java/org/kohsuke/stapler/jelly/AttributeExpressionTest.java
@@ -1,0 +1,24 @@
+package org.kohsuke.stapler.jelly;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlDivision;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import hudson.util.VersionNumber;
+import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
+import java.net.URL;
+import org.kohsuke.stapler.test.JettyTestCase;
+
+public class AttributeExpressionTest extends JettyTestCase {
+
+    public void testAttributeExpression() throws Exception {
+        WebClient wc = new WebClient();
+        HtmlPage page = wc.getPage(new URL(url, "/"));
+
+        HtmlDivision div = page.getHtmlElementById("build-timeline-div");
+        assertEquals("Timezone", div.asNormalizedText());
+        if (JavaSpecificationVersion.forCurrentJVM().isOlderThan(new VersionNumber("16"))) {
+            // TODO JENKINS-68215 does not yet work on Java 16+
+            assertNotNull(Float.parseFloat(div.getAttribute("data-hour-local-timezone")));
+        }
+    }
+}

--- a/jelly/src/test/java/org/kohsuke/stapler/jelly/BodyExpressionTest.java
+++ b/jelly/src/test/java/org/kohsuke/stapler/jelly/BodyExpressionTest.java
@@ -1,0 +1,33 @@
+package org.kohsuke.stapler.jelly;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.DomElement;
+import com.gargoylesoftware.htmlunit.html.DomNodeList;
+import com.gargoylesoftware.htmlunit.html.HtmlDefinitionDescription;
+import com.gargoylesoftware.htmlunit.html.HtmlDefinitionTerm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import hudson.util.VersionNumber;
+import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
+import java.net.URL;
+import org.kohsuke.stapler.test.JettyTestCase;
+
+public class BodyExpressionTest extends JettyTestCase {
+
+    public void testBodyExpression() throws Exception {
+        WebClient wc = new WebClient();
+        HtmlPage page = wc.getPage(new URL(url, "/"));
+
+        DomNodeList<DomElement> dts = page.getElementsByTagName("dt");
+        assertEquals(1, dts.size());
+        HtmlDefinitionTerm dt = (HtmlDefinitionTerm) dts.get(0);
+        assertEquals("Timezone", dt.asNormalizedText());
+
+        DomNodeList<DomElement> dds = page.getElementsByTagName("dd");
+        assertEquals(1, dds.size());
+        HtmlDefinitionDescription dd = (HtmlDefinitionDescription) dds.get(0);
+        if (JavaSpecificationVersion.forCurrentJVM().isOlderThan(new VersionNumber("16"))) {
+            // TODO JENKINS-68215 does not yet work on Java 16+
+            assertNotNull(Float.parseFloat(dd.asNormalizedText()));
+        }
+    }
+}

--- a/jelly/src/test/resources/org/kohsuke/stapler/jelly/AttributeExpressionTest/index.jelly
+++ b/jelly/src/test/resources/org/kohsuke/stapler/jelly/AttributeExpressionTest/index.jelly
@@ -1,0 +1,8 @@
+<j:jelly xmlns:st="jelly:stapler" xmlns:j="jelly:core">
+  <html>
+    <body>
+      <j:invokeStatic var="tz" className="java.util.TimeZone" method="getDefault"/>
+      <div id="build-timeline-div" data-hour-local-timezone="${(tz.rawOffset + tz.DSTSavings) / 3600000}">Timezone</div>
+    </body>
+  </html>
+</j:jelly>

--- a/jelly/src/test/resources/org/kohsuke/stapler/jelly/BodyExpressionTest/index.jelly
+++ b/jelly/src/test/resources/org/kohsuke/stapler/jelly/BodyExpressionTest/index.jelly
@@ -1,0 +1,11 @@
+<j:jelly xmlns:st="jelly:stapler" xmlns:j="jelly:core">
+  <html>
+    <body>
+      <j:invokeStatic var="tz" className="java.util.TimeZone" method="getDefault"/>
+      <dl>
+        <dt>Timezone</dt>
+        <dd>${(tz.rawOffset + tz.DSTSavings) / 3600000}</dd>
+      </dl>
+    </body>
+  </html>
+</j:jelly>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,11 @@
         <version>${jetty.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+        <version>2.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-test-harness-htmlunit</artifactId>
         <version>86.v3e0c60e7769e</version>


### PR DESCRIPTION
See [JENKINS-68215](https://issues.jenkins.io/browse/JENKINS-68215). Thanks to @NotMyFault for identifying this Java 17 issue in Stapler. This PR does not resolve the issue, but it adds two tests demonstrating the issue in Jelly views (which pass on Java 8 and Java 11 but fail on Java 17) as well as a test demonstrating that the issue is not present in Groovy views (which passes on Java 8, Java 11, and Java 17).