### PR TITLE
Use `ClassValue` for caching

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/ClassLoaderValue.java
+++ b/core/src/main/java/org/kohsuke/stapler/ClassLoaderValue.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler;
+
+import java.lang.reflect.Proxy;
+
+/**
+ * Like {@link ClassValue} but for a whole {@link ClassLoader}.
+ */
+abstract class ClassLoaderValue<T> {
+
+    private final ClassValue<T> storage = new ClassValue<T>() {
+        @Override
+        protected T computeValue(Class<?> type) {
+            return ClassLoaderValue.this.computeValue(type.getClassLoader());
+        }
+    };
+
+    protected abstract T computeValue(ClassLoader cl);
+
+    // A Class and its ClassLoader strongly refer to one another,
+    // so we can delegate to ClassValue if we can supply a Class loaded by a given ClassLoader,
+    // which is most easily done by asking for a Proxy of an otherwise unused interface.
+    public interface X {}
+
+    public final T get(ClassLoader cl) {
+        try {
+            cl.loadClass(X.class.getName());
+            // OK, X is visible to cl, can use trick
+        } catch (ClassNotFoundException x) {
+            // fallback, no caching; could use WeakHashMap though typically values would strongly hold keys so both could leak
+            return computeValue(cl);
+        }
+        Class<?> type = Proxy.getProxyClass(cl, X.class);
+        assert type.getClassLoader() == cl;
+        return storage.get(type);
+    }
+
+}

--- a/core/src/main/java/org/kohsuke/stapler/MetaClassLoader.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClassLoader.java
@@ -61,8 +61,6 @@ public class MetaClassLoader extends TearOffSupport {
 
     /**
      * All {@link MetaClass}es.
-     *
-     * Note that this permanently holds a strong reference to its key, i.e. is a memory leak.
      */
     private static final ClassLoaderValue<MetaClassLoader> classMap = new ClassLoaderValue<MetaClassLoader>() {
         @Override

--- a/core/src/main/java/org/kohsuke/stapler/MetaClassLoader.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClassLoader.java
@@ -25,12 +25,11 @@ package org.kohsuke.stapler;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import java.util.Map;
 import java.io.File;
+import java.lang.reflect.Proxy;
 import java.net.URLClassLoader;
 import java.net.URL;
 import java.net.MalformedURLException;
-import java.util.HashMap;
 
 /**
  * The stapler version of the {@link ClassLoader} object,
@@ -51,14 +50,7 @@ public class MetaClassLoader extends TearOffSupport {
         if(cl ==null)
             return null; // if no parent, delegate to the debug loader if available.
         
-        synchronized(classMap) {
-            MetaClassLoader mc = classMap.get(cl);
-            if(mc==null) {
-                mc = new MetaClassLoader(cl);
-                classMap.put(cl,mc);
-            }
-            return mc;
-        }
+        return classMap.get(cl);
     }
 
     /**
@@ -72,7 +64,12 @@ public class MetaClassLoader extends TearOffSupport {
      *
      * Note that this permanently holds a strong reference to its key, i.e. is a memory leak.
      */
-    private static final Map<ClassLoader,MetaClassLoader> classMap = new HashMap<>();
+    private static final ClassLoaderValue<MetaClassLoader> classMap = new ClassLoaderValue<MetaClassLoader>() {
+        @Override
+        protected MetaClassLoader computeValue(ClassLoader cl) {
+            return new MetaClassLoader(cl);
+        }
+    };
 
     static {
         debugLoader = createDebugLoader();
@@ -94,4 +91,6 @@ public class MetaClassLoader extends TearOffSupport {
         }
         return null;
     }
+
+
 }

--- a/core/src/main/java/org/kohsuke/stapler/MetaClassLoader.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClassLoader.java
@@ -91,6 +91,4 @@ public class MetaClassLoader extends TearOffSupport {
         }
         return null;
     }
-
-
 }

--- a/core/src/main/java/org/kohsuke/stapler/TearOffSupport.java
+++ b/core/src/main/java/org/kohsuke/stapler/TearOffSupport.java
@@ -78,5 +78,7 @@ public abstract class TearOffSupport {
      * @deprecated Unused?
      */
     @Deprecated
-    public <T> void setTearOff(Class<T> type, T instance) {}
+    public <T> void setTearOff(Class<T> type, T instance) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/core/src/main/java/org/kohsuke/stapler/WebApp.java
+++ b/core/src/main/java/org/kohsuke/stapler/WebApp.java
@@ -44,6 +44,7 @@ import java.util.Hashtable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import org.kohsuke.stapler.lang.KlassNavigator;
 
 /**
  * Object scoped to the entire webapp. Mostly used for configuring behavior of Stapler.
@@ -80,8 +81,9 @@ public class WebApp {
     public final ServletContext context;
 
     /**
-     * Duck-type wrappers for the given class.
+     * @deprecated Unused?
      */
+    @Deprecated
     public final Map<Class,Class[]> wrappers = new HashMap<>();
 
     /**
@@ -117,10 +119,8 @@ public class WebApp {
 
     /**
      * All {@link MetaClass}es.
-     *
-     * Note that this permanently holds a strong reference to its key, i.e. is a memory leak.
      */
-    private final Map<Klass<?>,MetaClass> classMap = new HashMap<>();
+    private volatile ClassValue<MetaClass> classMap;
 
     /**
      * Handles objects that are exported.
@@ -224,13 +224,19 @@ public class WebApp {
     
     public MetaClass getMetaClass(Klass<?> c) {
         if(c==null)     return null;
-        synchronized(classMap) {
-            MetaClass mc = classMap.get(c);
-            if(mc==null) {
-                mc = new MetaClass(this,c);
-                classMap.put(c,mc);
+        if (c.navigator == KlassNavigator.JAVA) {
+            if (classMap == null) {
+                classMap = new ClassValue<MetaClass>() {
+                    @Override
+                    protected MetaClass computeValue(Class<?> c) {
+                        return new MetaClass(WebApp.this, Klass.java(c));
+                    }
+                };
             }
-            return mc;
+            return classMap.get(c.toJavaClass());
+        } else {
+            // probably now impossible outside tests
+            return new MetaClass(this,c);
         }
     }
 
@@ -261,22 +267,14 @@ public class WebApp {
     }
     
     /**
-     * Convenience maintenance method to clear all the cached scripts for the given tearoff type.
-     *
-     * <p>
-     * This is useful when you want to have the scripts reloaded into the live system without
-     * the performance penalty of {@link MetaClass#NO_CACHE}.
-     *
-     * @see MetaClass#NO_CACHE
+     * @deprecated Unused?
      */
+    @Deprecated
     public void clearScripts(Class<? extends AbstractTearOff> clazz) {
-        synchronized (classMap) {
-            for (MetaClass v : classMap.values()) {
-                AbstractTearOff t = v.getTearOff(clazz);
-                if (t!=null)
-                    t.clearScripts();
-            }
-        }
+        // ClassValue cannot enumerate entries.
+        // If really needed, could be implemented by keeping a WeakHashMap<Class, Boolean>
+        // of classes added to classMap by getMetaClass that we could enumerate.
+        clearMetaClassCache();
     }
     
     /**
@@ -287,9 +285,8 @@ public class WebApp {
      * this call should not be called too often
      */
     public void clearMetaClassCache(){
-        synchronized (classMap) {
-            classMap.clear();
-        }
+        // No ClassValue.clear() method, so need to just null it out instead.
+        classMap = null;
     }
 
     void addStaplerServlet(String servletName, Stapler servlet) {

--- a/core/src/main/java/org/kohsuke/stapler/WebApp.java
+++ b/core/src/main/java/org/kohsuke/stapler/WebApp.java
@@ -225,15 +225,19 @@ public class WebApp {
     public MetaClass getMetaClass(Klass<?> c) {
         if(c==null)     return null;
         if (c.navigator == KlassNavigator.JAVA) {
-            if (classMap == null) {
-                classMap = new ClassValue<MetaClass>() {
-                    @Override
-                    protected MetaClass computeValue(Class<?> c) {
-                        return new MetaClass(WebApp.this, Klass.java(c));
-                    }
-                };
+            ClassValue<MetaClass> _classMap;
+            synchronized (this) {
+                if (classMap == null) {
+                    classMap = new ClassValue<MetaClass>() {
+                        @Override
+                        protected MetaClass computeValue(Class<?> c) {
+                            return new MetaClass(WebApp.this, Klass.java(c));
+                        }
+                    };
+                }
+                _classMap = classMap;
             }
-            return classMap.get(c.toJavaClass());
+            return _classMap.get(c.toJavaClass());
         } else {
             // probably now impossible outside tests
             return new MetaClass(this,c);
@@ -284,7 +288,7 @@ public class WebApp {
      * Take care that the generation of MetaClass information takes a bit of time and so 
      * this call should not be called too often
      */
-    public void clearMetaClassCache(){
+    public synchronized void clearMetaClassCache(){
         // No ClassValue.clear() method, so need to just null it out instead.
         classMap = null;
     }

--- a/core/src/main/java/org/kohsuke/stapler/export/ModelBuilder.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/ModelBuilder.java
@@ -40,6 +40,7 @@ public class ModelBuilder {
      * Registration happens in {@link Model#Model(ModelBuilder, Class, Class, String)} so that cyclic references
      * are handled correctly.
      */
+    // TODO unclear how to convert to ClassValue given registration from parent
     /*package*/ final Map<Class, Model> models = new ConcurrentHashMap<>();
 
     @NonNull

--- a/core/src/main/java/org/kohsuke/stapler/lang/Klass.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/Klass.java
@@ -16,7 +16,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * To support other JVM languages that use their own specific types to represent a class
  * (such as JRuby and Jython), we now use this object instead of {@link Class}. This allows
  * us to reuse much of the logic of class traversal/resource lookup across different languages.
- * 
+ * <em>But</em> after the removal of JRuby support, in practice this is used only for {@link Class}.
+ * <p>
  * This is a convenient tuple so that we can pass around a single argument instead of two.
  *
  * @param <C>

--- a/core/src/main/java/org/kohsuke/stapler/lang/KlassNavigator.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/KlassNavigator.java
@@ -17,7 +17,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Strategy pattern to provide navigation across class-like objects in other languages of JVM.
- *
+ * <p>
+ * After removal of JRuby support, {@link #JAVA} is the only implementation.
  * <p>
  * Implementations should be stateless and typically a singleton.
  *

--- a/core/src/test/java/org/kohsuke/stapler/MetaClassLoaderTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/MetaClassLoaderTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class MetaClassLoaderTest {
+
+    @Test
+    public void inheritanceAndCaching() {
+        ClassLoader cl1 = new URLClassLoader(new URL[0]);
+        ClassLoader cl2 = new URLClassLoader(new URL[0], cl1);
+        ClassLoader cl3 = new URLClassLoader(new URL[0], cl2);
+        ClassLoader cl4 = new URLClassLoader(new URL[0], cl1);
+        MetaClassLoader mcl3 = MetaClassLoader.get(cl3);
+        MetaClassLoader mcl1 = MetaClassLoader.get(cl1);
+        MetaClassLoader mcl2 = MetaClassLoader.get(cl2);
+        MetaClassLoader mcl4 = MetaClassLoader.get(cl4);
+        assertEquals(cl1, mcl1.loader);
+        assertEquals(cl2, mcl2.loader);
+        assertEquals(cl3, mcl3.loader);
+        assertEquals(cl4, mcl4.loader);
+        assertEquals(mcl1, mcl2.parent);
+        assertEquals(mcl2, mcl3.parent);
+        assertEquals(mcl1, mcl4.parent);
+        assertEquals(mcl1, MetaClassLoader.get(cl1));
+        assertEquals(mcl2, MetaClassLoader.get(cl2));
+        assertEquals(mcl3, MetaClassLoader.get(cl3));
+        assertEquals(mcl4, MetaClassLoader.get(cl4));
+    }
+
+}

--- a/groovy/src/test/java/org/kohsuke/stapler/jelly/groovy/GroovyClassLoaderTearOffTest.java
+++ b/groovy/src/test/java/org/kohsuke/stapler/jelly/groovy/GroovyClassLoaderTearOffTest.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -28,7 +27,7 @@ public class GroovyClassLoaderTearOffTest extends AbstractStaplerTest {
 
         try {
             MetaClassLoader mcl = webApp.getMetaClass(Foo.class).classLoader;
-            GroovyClassLoaderTearOff t = mcl.getTearOff(GroovyClassLoaderTearOff.class);
+            GroovyClassLoaderTearOff t = mcl.loadTearOff(GroovyClassLoaderTearOff.class);
             
             Files.write(tmp, "context.setVariable('x',1)".getBytes(StandardCharsets.UTF_8));
 
@@ -51,7 +50,7 @@ public class GroovyClassLoaderTearOffTest extends AbstractStaplerTest {
 
         try {
             MetaClassLoader mcl = webApp.getMetaClass(Foo.class).classLoader;
-            GroovyClassLoaderTearOff t = mcl.getTearOff(GroovyClassLoaderTearOff.class);
+            GroovyClassLoaderTearOff t = mcl.loadTearOff(GroovyClassLoaderTearOff.class);
 
             Files.write(tmp, "output.write(_('localizable'))".getBytes(StandardCharsets.UTF_8));
             Files.write(tmp.resolveSibling(tmp.getFileName().toString().replaceFirst("[.]groovy$", ".properties")), "localizable=Localizable".getBytes(StandardCharsets.ISO_8859_1));
@@ -75,7 +74,7 @@ public class GroovyClassLoaderTearOffTest extends AbstractStaplerTest {
 
         try {
             MetaClassLoader mcl = webApp.getMetaClass(Foo.class).classLoader;
-            GroovyClassLoaderTearOff t = mcl.getTearOff(GroovyClassLoaderTearOff.class);
+            GroovyClassLoaderTearOff t = mcl.loadTearOff(GroovyClassLoaderTearOff.class);
 
             Files.write(tmp, "def tz = java.util.TimeZone.getDefault()\ncontext.setVariable('x', (tz.rawOffset + tz.DSTSavings) / 3600000)".getBytes(StandardCharsets.UTF_8));
 

--- a/jrebel/src/main/java/org/kohsuke/stapler/JRebelFacet.java
+++ b/jrebel/src/main/java/org/kohsuke/stapler/JRebelFacet.java
@@ -22,6 +22,7 @@ import static java.util.logging.Level.*;
  */
 @MetaInfServices
 public class JRebelFacet extends Facet {
+    // Not obviously convertible to ClassValue.
     private Map<Class,MetaClass> metaClasses;
 
     public class ReloaderHook implements Runnable {


### PR DESCRIPTION
Generally a good idea for avoiding memory leaks, though that may not be a real issue in Jenkins since the `ClassLoader`s involved are those of plugins, which would never be collected during the JVM session anyway.

Motivated by a CloudBees CI thread dump showing a large number of threads blocked like this:

```
"Handling HEAD /jenkins/instance-identity/ from … : Jetty (winstone)-…" …
    - waiting to lock <…> (a java.util.HashMap)
      owned by "Handling GET /jenkins/job/someItem/configure from … : Jetty (winstone)-… SomeStuff/configure.jelly" …
    at org.kohsuke.stapler.WebApp.getMetaClass(WebApp.java:227)
    at org.kohsuke.stapler.WebApp.getMetaClass(WebApp.java:244)
    at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:762)
    at org.kohsuke.stapler.Stapler.invoke(Stapler.java:898)
    at org.kohsuke.stapler.Stapler.invoke(Stapler.java:694)
    at org.kohsuke.stapler.Stapler.service(Stapler.java:240)
    at …
```

all of them blocked by one HTTP handler thread

```
"Handling GET /jenkins/job/someItem/configure from … : Jetty (winstone)-… SomeStuff/configure.jelly" …
    - waiting to lock <…> (a hudson.ClassicPluginStrategy$AntClassLoader2)
      owned by "Computer.threadPoolForRemoting [#…]" …
    at java.lang.Class.forName0(Native Method)
    at …
    at java.lang.reflect.Method.getParameterAnnotations(Method.java:639)
    at org.kohsuke.stapler.Function$InstanceFunction.getParameterAnnotations(Function.java:423)
    at jenkins.security.stapler.DoActionFilter.keep(DoActionFilter.java:97)
    at jenkins.security.stapler.TypedFilter.isRoutableMethod(TypedFilter.java:131)
    at jenkins.security.stapler.TypedFilter.isSpecificClassStaplerRelevant(TypedFilter.java:98)
    at jenkins.security.stapler.TypedFilter.isStaplerRelevant(TypedFilter.java:65)
    at jenkins.security.stapler.TypedFilter.isStaplerRelevantCached(TypedFilter.java:57)
    at jenkins.security.stapler.TypedFilter.isClassAcceptable(TypedFilter.java:50)
    at jenkins.security.stapler.TypedFilter.keep(TypedFilter.java:267)
    at org.kohsuke.stapler.FunctionList.filter(FunctionList.java:48)
    at org.kohsuke.stapler.MetaClass.buildDispatchers(MetaClass.java:192)
    at org.kohsuke.stapler.MetaClass.<init>(MetaClass.java:98)
    at org.kohsuke.stapler.WebApp.getMetaClass(WebApp.java:230)
    at org.kohsuke.stapler.jelly.groovy.GroovyFacet.createRequestDispatcher(GroovyFacet.java:71)
    at org.kohsuke.stapler.RequestImpl.getView(RequestImpl.java:269)
    at org.kohsuke.stapler.RequestImpl.getView(RequestImpl.java:264)
    at hudson.model.Descriptor.getHelpFile(Descriptor.java:756)
    at hudson.model.Descriptor.getHelpFile(Descriptor.java:738)
    at …
    at org.apache.commons.jexl.ExpressionImpl.evaluate(ExpressionImpl.java:80)
    at hudson.ExpressionFactory2$JexlExpression.evaluate(ExpressionFactory2.java:74)
    at org.apache.commons.jelly.tags.core.CoreTagLibrary$3.run(CoreTagLibrary.java:134)
    at org.apache.commons.jelly.tags.core.CoreTagLibrary$1.run(CoreTagLibrary.java:98)
    at org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
    at org.apache.commons.jelly.tags.core.CoreTagLibrary$2.run(CoreTagLibrary.java:105)
    at org.kohsuke.stapler.jelly.CallTagLibScript.run(CallTagLibScript.java:120)
    at org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
    at org.apache.commons.jelly.tags.core.CoreTagLibrary$2.run(CoreTagLibrary.java:105)
    at org.kohsuke.stapler.jelly.JellyViewScript.run(JellyViewScript.java:95)
    at org.kohsuke.stapler.jelly.IncludeTag.doTag(IncludeTag.java:171)
    at org.apache.commons.jelly.impl.TagScript.run(TagScript.java:269)
    at …
    at org.kohsuke.stapler.Facet$1.dispatch(Facet.java:240)
    at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:766)
    at org.kohsuke.stapler.Stapler.invoke(Stapler.java:898)
    at org.kohsuke.stapler.MetaClass$4.doDispatch(MetaClass.java:281)
    at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:58)
    at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:766)
    at org.kohsuke.stapler.Stapler.invoke(Stapler.java:898)
    at org.kohsuke.stapler.MetaClass$4.doDispatch(MetaClass.java:281)
    at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:58)
    at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:766)
    at org.kohsuke.stapler.Stapler.invoke(Stapler.java:898)
    at org.kohsuke.stapler.Stapler.invoke(Stapler.java:694)
    at org.kohsuke.stapler.Stapler.service(Stapler.java:240)
    at …
```

While a contributing factor was the `Computer.threadPoolForRemoting` thread (not shown), blocked in class loading predating paralellism (introduced I think in https://github.com/jenkinsci/jenkins/pull/5698), this seems silly because some of the rendered threads are trying to load unrelated classes: `WebApp.classMap` was a bottleneck.
