### PR TITLE
Migrate from Hickory to Elementary

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -112,9 +112,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.jolira</groupId>
-      <artifactId>hickory</artifactId>
-      <version>1.0.0</version>
+      <groupId>com.karuslabs</groupId>
+      <artifactId>elementary</artifactId>
+      <version>1.1.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/ExportedBeanAnnotationProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/ExportedBeanAnnotationProcessorTest.java
@@ -1,96 +1,121 @@
 package org.kohsuke.stapler.jsr269;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.karuslabs.elementary.Results;
+import com.karuslabs.elementary.junit.JavacExtension;
+import com.karuslabs.elementary.junit.annotations.Inline;
+import com.karuslabs.elementary.junit.annotations.Options;
+import com.karuslabs.elementary.junit.annotations.Processors;
 import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.jvnet.hudson.annotation_indexer.AnnotationProcessorImpl;
 
-import net.java.dev.hickory.testing.Compilation;
-import static org.junit.Assert.*;
-import org.junit.Test;
-import org.kohsuke.stapler.export.Exported;
-import org.kohsuke.stapler.export.ExportedBean;
-
-public class ExportedBeanAnnotationProcessorTest {
+@ExtendWith(JavacExtension.class)
+@Options("-Werror")
+@Processors({
+    AnnotationProcessorImpl.class,
+    ExportedBeanAnnotationProcessor.class,
+})
+class ExportedBeanAnnotationProcessorTest {
 
     private void assertEqualsCRLF(String s1, String s2) {
         assertEquals(s1.replace("\r\n","\n"), s2.replace("\r\n","\n"));
     }
 
-    @Test public void basicOutput() {
-        Compilation compilation = new Compilation();
-        compilation.addSource("some.pkg.Stuff").
-                addLine("package some.pkg;").
-                addLine("import org.kohsuke.stapler.export.*;").
-                addLine("@ExportedBean public class Stuff {").
-                addLine("  /* this is not Javadoc */").
-                addLine("  @Exported public int getCount() {return 0;}").
-                addLine("  /** This gets the display name. */").
-                addLine("  @Exported(name=\"name\") public String getDisplayName() {return null;}").
-                addLine("}");
-        compilation.doCompile(null, "-source", "8", "-Xlint:none");
-        assertEquals(Collections.emptyList(), compilation.getDiagnostics());
-        assertEqualsCRLF("some.pkg.Stuff\n", Utils.getGeneratedResource(compilation, "META-INF/services/annotations/org.kohsuke.stapler.export.ExportedBean"));
-        assertEqualsCRLF("some.pkg.Stuff\n", Utils.getGeneratedResource(compilation, ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
-        assertEquals("{getDisplayName=This gets the display name. }", Utils.normalizeProperties(Utils.getGeneratedResource(compilation, "some/pkg/Stuff.javadoc")));
+    @Inline(
+            name = "some.pkg.Stuff",
+            source = {
+                "package some.pkg;",
+                "import org.kohsuke.stapler.export.*;",
+                "@ExportedBean public class Stuff {",
+                "  /* this is not Javadoc */",
+                "  @Exported public int getCount() {return 0;}",
+                "  /** This gets the display name. */",
+                "  @Exported(name=\"name\") public String getDisplayName() {return null;}",
+                "}"
+            })
+    @Test
+    void basicOutput(Results results) {
+        assertEquals(Collections.emptyList(), results.diagnostics);
+        assertEqualsCRLF("some.pkg.Stuff\n", Utils.getGeneratedResource(results.sources, "META-INF/services/annotations/org.kohsuke.stapler.export.ExportedBean"));
+        assertEqualsCRLF("some.pkg.Stuff\n", Utils.getGeneratedResource(results.sources, ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
+        assertEquals("{getDisplayName=This gets the display name. }", Utils.normalizeProperties(Utils.getGeneratedResource(results.sources, "some/pkg/Stuff.javadoc")));
     }
 
-    @Test public void noJavadoc() {
-        Compilation compilation = new Compilation();
-        compilation.addSource("some.pkg.Stuff").
-                addLine("package some.pkg;").
-                addLine("import org.kohsuke.stapler.export.*;").
-                addLine("@ExportedBean public class Stuff {").
-                addLine("  @Exported public int getCount() {return 0;}").
-                addLine("}");
-        compilation.doCompile(null, "-source", "8", "-Xlint:none");
-        assertEquals(Collections.emptyList(), compilation.getDiagnostics());
-        assertEqualsCRLF("some.pkg.Stuff\n", Utils.getGeneratedResource(compilation, "META-INF/services/annotations/org.kohsuke.stapler.export.ExportedBean"));
-        assertEqualsCRLF("some.pkg.Stuff\n", Utils.getGeneratedResource(compilation, ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
+    @Inline(
+            name = "some.pkg.Stuff",
+            source = {
+                "package some.pkg;",
+                "import org.kohsuke.stapler.export.*;",
+                "@ExportedBean public class Stuff {",
+                "  @Exported public int getCount() {return 0;}",
+                "}"
+            })
+    @Test
+    void noJavadoc(Results results) {
+        assertEquals(Collections.emptyList(), results.diagnostics);
+        assertEqualsCRLF("some.pkg.Stuff\n", Utils.getGeneratedResource(results.sources, "META-INF/services/annotations/org.kohsuke.stapler.export.ExportedBean"));
+        assertEqualsCRLF("some.pkg.Stuff\n", Utils.getGeneratedResource(results.sources, ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
         // TODO should it be null, i.e. is it desired to create an empty *.javadoc file?
-        assertEquals("{}", Utils.normalizeProperties(Utils.getGeneratedResource(compilation, "some/pkg/Stuff.javadoc")));
+        assertEquals("{}", Utils.normalizeProperties(Utils.getGeneratedResource(results.sources, "some/pkg/Stuff.javadoc")));
     }
-    
-    @ExportedBean public static abstract class Super {
-        @Exported public abstract int getCount();
-    }
-    @Test public void subclassOfExportedBean() {
-        Compilation compilation = new Compilation();
-        compilation.addSource("some.pkg.Stuff").
-                addLine("package some.pkg;").
-                addLine("import org.kohsuke.stapler.export.*;").
-                addLine("public class Stuff extends " + Super.class.getCanonicalName() + " {").
-                addLine("  @Override public int getCount() {return 0;}").
-                addLine("}");
-        compilation.doCompile(null, "-source", "8", "-Xlint:none");
-        assertEquals(Collections.emptyList(), compilation.getDiagnostics());
+
+    @Inline(
+            name = "some.pkg.Super",
+            source = {
+                "package some.pkg;",
+                "import org.kohsuke.stapler.export.*;",
+                "@ExportedBean public abstract class Super {",
+                "  @Exported public abstract int getCount();",
+                "}",
+            })
+    @Inline(
+            name = "some.pkg.Stuff",
+            source = {
+                "package some.pkg;",
+                "import org.kohsuke.stapler.export.*;",
+                "public class Stuff extends some.pkg.Super {",
+                "  @Override public int getCount() {return 0;}",
+                "}"
+            })
+    @Test
+    void subclassOfExportedBean(Results results) {
+        assertEquals(Collections.emptyList(), results.diagnostics);
         /* #7188605: broken in JDK 6u33 + org.jvnet.hudson:annotation-indexer:1.2:
-        assertEquals("some.pkg.Stuff\n", Utils.getGeneratedResource(compilation, "META-INF/services/annotations/org.kohsuke.stapler.export.ExportedBean"));
+        assertEquals("some.pkg.Stuff\n", Utils.getGeneratedResource(results.sources, "META-INF/services/annotations/org.kohsuke.stapler.export.ExportedBean"));
         */
         // TODO is it intentional that these are not listed here? (example: hudson.plugins.mercurial.MercurialSCM)
-        assertNull(Utils.getGeneratedResource(compilation, ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
-        assertNull(Utils.normalizeProperties(Utils.getGeneratedResource(compilation, "some/pkg/Stuff.javadoc")));
+        assertEqualsCRLF("some.pkg.Super\n", Utils.getGeneratedResource(results.sources, ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
+        assertNull(Utils.normalizeProperties(Utils.getGeneratedResource(results.sources, "some/pkg/Stuff.javadoc")));
     }
 
-    @Test public void incremental() {
-        Compilation compilation = new Compilation();
-        compilation.addSource("some.pkg.Stuff").
-                addLine("package some.pkg;").
-                addLine("import org.kohsuke.stapler.export.*;").
-                addLine("@" + SourceGeneratingAnnotation.class.getCanonicalName()).
-                addLine("@ExportedBean public class Stuff {").
-                addLine("  @Exported public int getCount() {return 0;}").
-                addLine("}");
-        compilation.doCompile(null, "-source", "8", "-Xlint:none");
-        assertEquals(Collections.emptyList(), compilation.getDiagnostics());
-        assertEqualsCRLF("some.pkg.Stuff\n", Utils.getGeneratedResource(compilation, ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
-        compilation = new Compilation(compilation);
-        compilation.addSource("some.pkg.MoreStuff").
-                addLine("package some.pkg;").
-                addLine("import org.kohsuke.stapler.export.*;").
-                addLine("@ExportedBean public class MoreStuff {").
-                addLine("  @Exported public int getCount() {return 0;}").
-                addLine("}");
-        compilation.doCompile(null, "-source", "8", "-Xlint:none");
-        assertEquals(Collections.emptyList(), compilation.getDiagnostics());
-        assertEqualsCRLF("some.pkg.MoreStuff\nsome.pkg.Stuff\n", Utils.getGeneratedResource(compilation, ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
+    @Inline(
+            name = "some.pkg.Stuff",
+            source = {
+                "package some.pkg;",
+                "import org.kohsuke.stapler.export.*;",
+                "@org.kohsuke.stapler.jsr269.SourceGeneratingAnnotation",
+                "@ExportedBean public class Stuff {",
+                "  @Exported public int getCount() {return 0;}",
+                "}"
+            })
+    @Inline(
+            name = "some.pkg.MoreStuff",
+            source = {
+                "package some.pkg;",
+                "import org.kohsuke.stapler.export.*;",
+                "@ExportedBean public class MoreStuff {",
+                "  @Exported public int getCount() {return 0;}",
+                "}"
+            })
+    @Test
+    void multiple(Results results) {
+        assertEquals(Collections.emptyList(), results.diagnostics);
+        assertEqualsCRLF("some.pkg.MoreStuff\nsome.pkg.Stuff\n", Utils.getGeneratedResource(results.sources, "META-INF/services/annotations/org.kohsuke.stapler.export.ExportedBean"));
+        assertEqualsCRLF("some.pkg.MoreStuff\nsome.pkg.Stuff\n", Utils.getGeneratedResource(results.sources, ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
     }
 
     // TODO nested classes - currently saved as qualified rather than binary name, intentional?

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/QueryParameterAnnotationProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/QueryParameterAnnotationProcessorTest.java
@@ -1,27 +1,36 @@
 package org.kohsuke.stapler.jsr269;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.karuslabs.elementary.Results;
+import com.karuslabs.elementary.junit.JavacExtension;
+import com.karuslabs.elementary.junit.annotations.Inline;
+import com.karuslabs.elementary.junit.annotations.Options;
+import com.karuslabs.elementary.junit.annotations.Processors;
 import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import net.java.dev.hickory.testing.Compilation;
-import org.junit.Test;
+@ExtendWith(JavacExtension.class)
+@Options("-Werror")
+@Processors(QueryParameterAnnotationProcessor.class)
+class QueryParameterAnnotationProcessorTest {
 
-import static org.junit.Assert.*;
-
-public class QueryParameterAnnotationProcessorTest {
-
-    @Test public void basicOutput() {
-        Compilation compilation = new Compilation();
-        compilation.addSource("some.pkg.Stuff").
-                addLine("package some.pkg;").
-                addLine("import org.kohsuke.stapler.QueryParameter;").
-                addLine("public class Stuff {").
-                addLine("  public void doOneThing(@QueryParameter String key) {}").
-                addLine("  public void doAnother(@QueryParameter(\"ignoredHere\") String name, @QueryParameter String address) {}").
-                addLine("}");
-        compilation.doCompile(null, "-source", "8", "-Xlint:none");
-        assertEquals(Collections.emptyList(), compilation.getDiagnostics());
-        assertEquals("key", Utils.getGeneratedResource(compilation, "some/pkg/Stuff/doOneThing.stapler"));
-        assertEquals("name,address", Utils.getGeneratedResource(compilation, "some/pkg/Stuff/doAnother.stapler"));
+    @Inline(
+            name = "some.pkg.Stuff",
+            source = {
+                "package some.pkg;",
+                "import org.kohsuke.stapler.QueryParameter;",
+                "public class Stuff {",
+                "  public void doOneThing(@QueryParameter String key) {}",
+                "  public void doAnother(@QueryParameter(\"ignoredHere\") String name, @QueryParameter String address) {}",
+                "}",
+            })
+    @Test
+    void basicOutput(Results results) {
+        assertEquals(Collections.emptyList(), results.diagnostics);
+        assertEquals("key", Utils.getGeneratedResource(results.sources, "some/pkg/Stuff/doOneThing.stapler"));
+        assertEquals("name,address", Utils.getGeneratedResource(results.sources, "some/pkg/Stuff/doAnother.stapler"));
     }
 
     // TODO nested classes use qualified rather than binary name

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/SourceGeneratingAnnotationProcessor.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/SourceGeneratingAnnotationProcessor.java
@@ -41,7 +41,7 @@ import javax.tools.Diagnostic;
 import javax.tools.JavaFileObject;
 import org.kohsuke.MetaInfServices;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
+@SupportedSourceVersion(SourceVersion.RELEASE_11)
 @SupportedAnnotationTypes("org.kohsuke.stapler.jsr269.SourceGeneratingAnnotation")
 @MetaInfServices(Processor.class)
 public class SourceGeneratingAnnotationProcessor extends AbstractProcessor {

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,10 @@
       <id>repo.jenkins-ci.org</id>
       <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
+    <repository>
+      <id>elementary-releases</id>
+      <url>https://repo.karuslabs.com/repository/elementary-releases/</url>
+    </repository>
   </repositories>
 
   <pluginRepositories>


### PR DESCRIPTION
We currently test our annotation processors with [Hickory](https://github.com/vietj/hickory), an outdated library that hasn't been maintained in over a decade. This PR switches us to [Elementary](https://github.com/Pante/elementary), a modern and well-maintained annotation processor testing library. Note that Elementary requires both Java 11 and JUnit 5, both of which we now support.