### PR TITLE
Upgrade Maven Jellydoc and Stapler plugins

### DIFF
--- a/jelly/pom.xml
+++ b/jelly/pom.xml
@@ -11,6 +11,10 @@
   <name>Stapler Jelly module</name>
   <description>Jelly binding for Stapler</description>
 
+  <properties>
+    <maven-jellydoc-plugin.version>1.9</maven-jellydoc-plugin.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -37,7 +41,7 @@
       <!-- only needed for annotations, hence optional -->
       <groupId>org.jvnet.maven-jellydoc-plugin</groupId>
       <artifactId>jellydoc-annotations</artifactId>
-      <version>1.5</version>
+      <version>${maven-jellydoc-plugin.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
@@ -135,7 +139,7 @@
       <plugin>
         <groupId>org.jvnet.maven-jellydoc-plugin</groupId>
         <artifactId>maven-jellydoc-plugin</artifactId>
-        <version>1.5</version>
+        <version>${maven-jellydoc-plugin.version}</version>
         <dependencies>
           <dependency>
             <groupId>com.github.olivergondza</groupId>
@@ -178,7 +182,7 @@
           <plugin>
             <groupId>org.jvnet.maven-jellydoc-plugin</groupId>
             <artifactId>maven-jellydoc-plugin</artifactId>
-            <version>1.5</version>
+            <version>${maven-jellydoc-plugin.version}</version>
           </plugin>
         </plugins>
       </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.85</version>
+    <version>1.86</version>
     <relativePath />
   </parent>
   <groupId>org.kohsuke.stapler</groupId>


### PR DESCRIPTION
Upgrades these two in-house Maven plugins to the latest releases I just put out today (with Maven 3 APIs).