### PR TITLE
Remove `junit-bom` from managed dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,13 +52,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.junit</groupId>
-        <artifactId>junit-bom</artifactId>
-        <version>5.9.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
         <version>${jetty.version}</version>


### PR DESCRIPTION
This is now part of the parent POM.