### PR TITLE
Make `ClassLoaderValue` compatible with PowerMock

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/ClassLoaderValue.java
+++ b/core/src/main/java/org/kohsuke/stapler/ClassLoaderValue.java
@@ -45,14 +45,15 @@ abstract class ClassLoaderValue<T> {
     public interface X {}
 
     public final T get(ClassLoader cl) {
+        Class<?> x;
         try {
-            cl.loadClass(X.class.getName());
-            // OK, X is visible to cl, can use trick
-        } catch (ClassNotFoundException x) {
+            x = cl.loadClass(X.class.getName());
+            // OK, X is visible to cl, can use trick; note that x != X.class when using PowerMock
+        } catch (ClassNotFoundException e) {
             // fallback, no caching; could use WeakHashMap though typically values would strongly hold keys so both could leak
             return computeValue(cl);
         }
-        Class<?> type = Proxy.getProxyClass(cl, X.class);
+        Class<?> type = Proxy.getProxyClass(cl, x);
         assert type.getClassLoader() == cl;
         return storage.get(type);
     }


### PR DESCRIPTION
Amending #370. https://github.com/jenkinsci/email-ext-plugin/pull/311 etc. were filed because it turned out there were problems running `plugin-compat-tester` against plugins still using PowerMock (discouraged: https://github.com/jenkinsci/plugin-pom/pull/442):

```
java.lang.ExceptionInInitializerError
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:315)
	at javassist.runtime.Desc.getClassObject(Desc.java:72)
	at javassist.runtime.Desc.getClassType(Desc.java:181)
	at javassist.runtime.Desc.getType(Desc.java:151)
	at javassist.runtime.Desc.getType(Desc.java:107)
	at io.jenkins.blueocean.service.embedded.BaseTest.<init>(BaseTest.java:46)
	at io.jenkins.blueocean.service.embedded.ContainerFilterTest.<init>(ContainerFilterTest.java:34)
	at …
Caused by: java.lang.IllegalArgumentException: org.kohsuke.stapler.ClassLoaderValue$X referenced from a method is not visible from class loader
	at java.base/java.lang.reflect.Proxy$ProxyBuilder.ensureVisible(Proxy.java:858)
	at java.base/java.lang.reflect.Proxy$ProxyBuilder.validateProxyInterfaces(Proxy.java:681)
	at java.base/java.lang.reflect.Proxy$ProxyBuilder.<init>(Proxy.java:627)
	at java.base/java.lang.reflect.Proxy$ProxyBuilder.<init>(Proxy.java:635)
	at java.base/java.lang.reflect.Proxy.lambda$getProxyConstructor$0(Proxy.java:415)
	at java.base/jdk.internal.loader.AbstractClassLoaderValue$Memoizer.get(AbstractClassLoaderValue.java:329)
	at java.base/jdk.internal.loader.AbstractClassLoaderValue.computeIfAbsent(AbstractClassLoaderValue.java:205)
	at java.base/java.lang.reflect.Proxy.getProxyConstructor(Proxy.java:413)
	at java.base/java.lang.reflect.Proxy.getProxyClass(Proxy.java:384)
	at org.kohsuke.stapler.ClassLoaderValue.get(ClassLoaderValue.java:55)
	at org.kohsuke.stapler.MetaClassLoader.get(MetaClassLoader.java:53)
	at org.kohsuke.stapler.MetaClassLoader.<init>(MetaClassLoader.java:46)
	at org.jvnet.hudson.test.JenkinsRule.<clinit>(JenkinsRule.java:2792)
	... 31 more
```

Debugging shows that `cl` was e.g. `AppClassLoader` whereas `X.class` was from `org.powermock.core.classloader.javassist.JavassistMockClassLoader`. Use the version loaded from `cl`.
