### PR TITLE
Exclude broken `com.karuslabs:annotations` snapshot dep

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -111,6 +111,12 @@
       <artifactId>elementary</artifactId>
       <version>1.1.2</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.karuslabs</groupId>
+          <artifactId>annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-httpclient</groupId>


### PR DESCRIPTION
Fixes an error introduced by #494. Somehow when I build this locally (3.8.6, JDK 11) I am getting

```console
$ mvn -Pquick-build clean install -U
…
[INFO] --------------------< org.kohsuke.stapler:stapler >---------------------
[INFO] Building Stapler 999999-SNAPSHOT                                   [2/6]
[INFO] --------------------------------[ jar ]---------------------------------
Downloading from repo.jenkins-ci.org: https://repo.jenkins-ci.org/public/com/karuslabs/annotations/4.9.0-SNAPSHOT/maven-metadata.xml
Downloading from elementary-releases: https://repo.karuslabs.com/repository/elementary-releases/com/karuslabs/annotations/4.9.0-SNAPSHOT/maven-metadata.xml
Downloading from cloudbees-internal: https://nexus-internal.cloudbees.com/content/groups/staged/com/karuslabs/annotations/4.9.0-SNAPSHOT/maven-metadata.xml
Downloading from repo.jenkins-ci.org: https://repo.jenkins-ci.org/public/com/karuslabs/annotations/4.9.0-SNAPSHOT/annotations-4.9.0-SNAPSHOT.pom
Downloading from elementary-releases: https://repo.karuslabs.com/repository/elementary-releases/com/karuslabs/annotations/4.9.0-SNAPSHOT/annotations-4.9.0-SNAPSHOT.pom
Downloading from cloudbees-internal: https://nexus-internal.cloudbees.com/content/groups/staged/com/karuslabs/annotations/4.9.0-SNAPSHOT/annotations-4.9.0-SNAPSHOT.pom
[WARNING] The POM for com.karuslabs:annotations:jar:4.9.0-SNAPSHOT is missing, no dependency information available
Downloading from repo.jenkins-ci.org: https://repo.jenkins-ci.org/public/com/karuslabs/annotations/4.9.0-SNAPSHOT/annotations-4.9.0-SNAPSHOT.jar
Downloading from elementary-releases: https://repo.karuslabs.com/repository/elementary-releases/com/karuslabs/annotations/4.9.0-SNAPSHOT/annotations-4.9.0-SNAPSHOT.jar
Downloading from cloudbees-internal: https://nexus-internal.cloudbees.com/content/groups/staged/com/karuslabs/annotations/4.9.0-SNAPSHOT/annotations-4.9.0-SNAPSHOT.jar
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Stapler 999999-SNAPSHOT:
[INFO] 
[INFO] Stapler ............................................ SUCCESS [  2.007 s]
[INFO] Stapler ............................................ FAILURE [  1.581 s]
[INFO] Stapler JSP module ................................. SKIPPED
[INFO] Stapler Jelly module ............................... SKIPPED
[INFO] Stapler Groovy module .............................. SKIPPED
[INFO] Stapler JRebel module .............................. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.675 s
[INFO] Finished at: 2022-09-06T11:17:55-04:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project stapler: Could not resolve dependencies for project org.kohsuke.stapler:stapler:jar:999999-SNAPSHOT: Could not find artifact com.karuslabs:annotations:jar:4.9.0-SNAPSHOT in repo.jenkins-ci.org (https://repo.jenkins-ci.org/public/) -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :stapler
```

Not really sure where this is coming from. Presumably something to do with my local `mirrorOf` settings, even though I have added `!elementary-releases` already.
