### PR TITLE
Remove usages of Commons HttpClient 3.x from tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -119,12 +119,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <version>3.1-jenkins-3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpmime</artifactId>
       <version>4.5.13</version>


### PR DESCRIPTION
This library has been deprecated for well over a decade and was recently removed from core.