### PR TITLE
Restore Artifact Caching Proxy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
  * easy Linux/Windows testing and produces incrementals. The only feature that relates to plugins is
  * allowing one to test against multiple Jenkins versions.
  */
-buildPlugin(useContainerAgent: true, useArtifactCachingProxy: false, configurations: [
+buildPlugin(useContainerAgent: true, configurations: [
   [ platform: 'linux', jdk: '11' ],
   [ platform: 'windows', jdk: '11' ],
   [ platform: 'linux', jdk: '17' ],


### PR DESCRIPTION
Follow-up of https://github.com/jenkins-infra/jenkins-infra/pull/2630, restore Artifact Caching Proxy disabled in [`0da3f90` (#439)](https://github.com/jenkinsci/stapler/pull/439/commits/0da3f9010cbb570d3811808482ed9adfbeeb0d8c).

The ACP now ignores `elementary-releases` Maven repository as the `com.karuslabs:elementary:jar:1.1.3` artifact isn't published on Maven Central.

Closes #440 
Closes https://github.com/jenkins-infra/helpdesk/issues/3382