### PR TITLE
Document 'since' attribute tag

### DIFF
--- a/docs/jelly-taglib-ref.adoc
+++ b/docs/jelly-taglib-ref.adoc
@@ -363,6 +363,8 @@ attribute expects as values.
 
 |deprecated |boolean |If the attribute is deprecated, set to true. Use
 of the deprecated attribute will cause a warning.
+
+|since |String |Used to track when the attribute was added to the API surface.
 |===
 
 [#jelly:adjunct]##

--- a/docs/taglib-jelly.xsd
+++ b/docs/taglib-jelly.xsd
@@ -470,6 +470,11 @@
  Use of the deprecated attribute will cause a warning.</xsd:documentation>
 </xsd:annotation>
 </xsd:attribute>
+<xsd:attribute name="since">
+<xsd:annotation>
+<xsd:documentation>Used to track when the attribute was added to the API surface.</xsd:documentation>
+</xsd:annotation>
+</xsd:attribute>
 <xsd:attribute name="trim">
 <xsd:annotation>
 <xsd:documentation/>


### PR DESCRIPTION
The tag does already exist, see https://github.com/jenkinsci/stapler/blob/cea4497990e88143e543410ea0817c15b3e86d1a/jelly/src/main/java/org/kohsuke/stapler/jelly/AttributeTag.java#L75-L79, yet remained undocumented.
This PR takes care of that.