### PR TITLE
[JENKINS-71236] Stapler Ajax Proxy is broken (regression in 2.404)

### DIFF
--- a/core/src/main/resources/org/kohsuke/stapler/bind.js
+++ b/core/src/main/resources/org/kohsuke/stapler/bind.js
@@ -42,19 +42,22 @@ function makeStaplerProxy(url,staplerCrumb,methods) {
             })
             .then(function(response) {
                 if (response.ok) {
+                    var t = {
+                        status: response.status,
+                        statusText: response.statusText,
+                    };
                     if (response.headers.has('content-type') && response.headers.get('content-type').startsWith('application/json')) {
                         response.json().then(function(responseObject) {
-                            var t = {};
                             t.responseObject = function() {
                                 return responseObject;
                             };
+                            t.responseJSON = responseObject;
                             if (callback != null) {
                                 callback(t);
                             }
                         });
                     } else {
                         response.text().then(function(responseText) {
-                            var t = {};
                             t.responseText = responseText;
                             if (callback != null) {
                                 callback(t);


### PR DESCRIPTION
The object passed to the callback was only ever documented to have a `responseObject` method that, when invoked, returned JSON, but in practice various consumers had come to depend on this returning a Prototype [Ajax.Response](http://api.prototypejs.org/ajax/Ajax/Response/index.html) object. Already when developing #452 I observed the need for a `responseText` field to satisfy consumers in Jenkins core, but I did not think that anybody consuming the JSON representation would be using the undocumented `responseJSON` field instead of the documented `responseObject()` function to retrieve this data. Well, the ECharts API plugin does. This is arguably an abuse of this API, but at this point it is too late to correct all consumers: we might as well accept that this is part of the expected calling convention. Accordingly I have enhanced the callback object to pass not only `responseJSON` but also `status` and `statusText`, implementing more of the Prototype `Ajax.Response` API to guard against any further regressions. I took a quick look at other consumers of `st:bind` and did not see them using any of the other portions of the `Ajax.Response` API. To test this, I reproduced the problem as described in Jira and verified it no longer occurred after this patch.