### PR TITLE
Log in `AbstractTearOff` about time to parse resources

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/AbstractTearOff.java
+++ b/core/src/main/java/org/kohsuke/stapler/AbstractTearOff.java
@@ -162,8 +162,16 @@ public abstract class AbstractTearOff<CLT,S,E extends Exception> extends Caching
                     }
                 }
             } else {
-                LOGGER.log(Level.FINE, "standard CachingScriptLoader logic applies to {0}", res);
-                return parseScript(res);
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    long start = System.nanoTime();
+                    try {
+                        return parseScript(res);
+                    } finally {
+                        LOGGER.log(Level.FINE, "standard CachingScriptLoader logic applies to {0} parsed in {1}ms", new Object[] {res, (System.nanoTime() - start) / 1_000_000});
+                    }
+                } else {
+                    return parseScript(res);
+                }
             }
         }
 


### PR DESCRIPTION
Was curious about speed of loading Groovy views during first startup.