### PR TITLE
Rely on parent pom spotbugs configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,10 +46,6 @@
     <scmTag>HEAD</scmTag>
     <jetty.version>10.0.18</jetty.version>
     <gitHubRepo>jenkinsci/stapler</gitHubRepo>
-    <!-- TODO: Remove when parent pom is using this version or newer -->
-    <!-- https://github.com/jenkinsci/pom/pull/510 -->
-    <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
-    <spotbugs.omitVisitors>FindReturnRef,ConstructorThrow</spotbugs.omitVisitors>    
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Use parent pom spotbugs configuration

Removes 8537eb1f1e79234b70a6384299db5e97f9cc7641 workaround that was added in pull request https://github.com/jenkinsci/stapler/pull/507

### Testing done

Confirmed that spotbugs output is still silent after the change.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
