### PR TITLE
Use text/javascript content type, not application/javascript

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/bind/BoundObjectTable.java
+++ b/core/src/main/java/org/kohsuke/stapler/bind/BoundObjectTable.java
@@ -98,7 +98,7 @@ public class BoundObjectTable implements StaplerFallback {
             return;
         }
 
-        rsp.setContentType("application/javascript");
+        rsp.setContentType("text/javascript");
         final PrintWriter writer = rsp.getWriter();
 
         if ("/null".equals(boundUrl)) {

--- a/core/src/main/java/org/kohsuke/stapler/export/Flavor.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Flavor.java
@@ -40,7 +40,7 @@ public enum Flavor {
             return new JSONDataWriter(w,config);
         }
     },
-    JSONP("application/javascript;charset=UTF-8") {
+    JSONP("text/javascript;charset=UTF-8") {
         @Override
         public DataWriter createDataWriter(Object bean, Writer w, ExportConfig config) throws IOException {
             return new JSONDataWriter(w,config);

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/BindTag.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/BindTag.java
@@ -117,7 +117,7 @@ public class BindTag extends AbstractStaplerTag {
         } else {
             attributes.addAttribute("", "src", "src", "", bound.getProxyScriptURL(varName));
         }
-        attributes.addAttribute("", "type", "type", "", "application/javascript");
+        attributes.addAttribute("", "type", "type", "", "text/javascript");
         out.startElement("script", attributes);
         out.endElement("script");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-test-harness-htmlunit</artifactId>
-        <version>168.v36080d5e8d36</version>
+        <version>169.v1a_eed8806921</version>
       </dependency>
       <dependency>
         <groupId>org.kohsuke.metainf-services</groupId>


### PR DESCRIPTION
## Use text/javascript content type, not application/javascript

A work in progress pull request to evaluate HTMLUnit 3.11.0 and an attempt to suppress the new HTMLUnit 3.11.0 warnings for uses of the obsolete application/javascript content type.

- Use text/javascript content type
- Test with HTMLUnit 3.11.0 (use an incremental build)

https://github.com/HtmlUnit/htmlunit/issues/710 raised by @jtnord and fixed in HTMLUnit 3.11.0 reports a warning when it sees the application/javascript content type.  Avoid those warnings by using the text/javascript content type.
    
https://github.com/jenkinsci/stapler/issues/515 notes that the application/javascript content type has been declared obsolete and is replaced by the text/javascript content type.
    
Official docs that confirm application/javascript is obsolete include:
    
* https://datatracker.ietf.org/doc/rfc9239/
* https://www.iana.org/assignments/media-types/application/javascript
    
https://github.com/jenkinsci/jenkins-test-harness-htmlunit/pull/140 offers a dependabot upgrade from HTMLUnit 3.10.0 to 3.11.0.

### Testing done

Ran automated tests with breakpoints at the changed lines and confirmed that they are **not** reached by automated tests.  Modified one automated test to reach a changed line and confirmed that the test passed, though it did not assert anything about the change of content type.  Reverted the automated test modification because it was little value.  Will use the incremental build to run tests in Jenkins core.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
