### PR TITLE
Enable Checkstyle

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/AbstractTearOff.java
+++ b/core/src/main/java/org/kohsuke/stapler/AbstractTearOff.java
@@ -138,7 +138,7 @@ public abstract class AbstractTearOff<CLT, S, E extends Exception> extends Cachi
                                     script = parseScript(res);
                                 } finally {
                                     LOGGER.log(Level.FINE, "cache miss; took {0}ms to parse {1}", new Object[] {
-                                        (System.nanoTime() - start) / 1_000_000, res
+                                        (System.nanoTime() - start) / 1_000_000, res,
                                     });
                                 }
                             } else {

--- a/core/src/main/java/org/kohsuke/stapler/BytecodeReadingParanamer.java
+++ b/core/src/main/java/org/kohsuke/stapler/BytecodeReadingParanamer.java
@@ -511,7 +511,6 @@ final class BytecodeReadingParanamer {
          * @param classVisitor the visitor that must visit this class.
          */
         private void accept(final TypeCollector classVisitor) {
-            char[] c = new char[maxStringLength]; // buffer used to read strings
             int i, j, k; // loop variables
             int u, v, w; // indexes in b
 
@@ -566,6 +565,8 @@ final class BytecodeReadingParanamer {
                     u += 6 + readInt(u + 2);
                 }
             }
+
+            char[] c = new char[maxStringLength]; // buffer used to read strings
 
             // visits the methods
             i = readUnsignedShort(u);

--- a/core/src/main/java/org/kohsuke/stapler/Function.java
+++ b/core/src/main/java/org/kohsuke/stapler/Function.java
@@ -234,8 +234,6 @@ public abstract class Function {
                 switch (methods.size()) {
                     case 0:
                         return RETURN_NULL;
-                    default:
-                        throw new IllegalArgumentException("Too many 'fromStapler' methods on " + from);
                     case 1:
                         Method m = ((MethodFunction) methods.get(0)).m;
                         return new MethodFunction(m) {
@@ -260,6 +258,8 @@ public abstract class Function {
                                 return m.invoke(null, args);
                             }
                         };
+                    default:
+                        throw new IllegalArgumentException("Too many 'fromStapler' methods on " + from);
                 }
             }
         };
@@ -293,6 +293,8 @@ public abstract class Function {
                             case PREINVOKE:
                                 f = new PreInvokeInterceptedFunction(f, i);
                                 break;
+                            default:
+                                throw new IllegalArgumentException("Unknown Stage: " + ia.stage());
                         }
                     } catch (InstantiationException e) {
                         throw (Error)

--- a/core/src/main/java/org/kohsuke/stapler/HttpDeletable.java
+++ b/core/src/main/java/org/kohsuke/stapler/HttpDeletable.java
@@ -37,25 +37,25 @@ public interface HttpDeletable {
      * Called when HTTP DELETE method is invoked.
      */
     void delete(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException;
-}
 
-/**
- * {@link Dispatcher} that processes {@link HttpDeletable}
- */
-class HttpDeletableDispatcher extends Dispatcher {
-    @Override
-    public boolean dispatch(RequestImpl req, ResponseImpl rsp, Object node)
-            throws IOException, ServletException, IllegalAccessException, InvocationTargetException {
-        if (!req.tokens.hasMore() && req.getMethod().equals("DELETE")) {
-            ((HttpDeletable) node).delete(req, rsp);
-            return true;
+    /**
+     * {@link Dispatcher} that processes {@link HttpDeletable}
+     */
+    class HttpDeletableDispatcher extends Dispatcher {
+        @Override
+        public boolean dispatch(RequestImpl req, ResponseImpl rsp, Object node)
+                throws IOException, ServletException, IllegalAccessException, InvocationTargetException {
+            if (!req.tokens.hasMore() && req.getMethod().equals("DELETE")) {
+                ((HttpDeletable) node).delete(req, rsp);
+                return true;
+            }
+
+            return false;
         }
 
-        return false;
-    }
-
-    @Override
-    public String toString() {
-        return "delete() for url=/ with DELETE";
+        @Override
+        public String toString() {
+            return "delete() for url=/ with DELETE";
+        }
     }
 }

--- a/core/src/main/java/org/kohsuke/stapler/MetaClass.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClass.java
@@ -111,7 +111,7 @@ public class MetaClass extends TearOffSupport {
         dispatchers.add(new DirectoryishDispatcher());
 
         if (HttpDeletable.class.isAssignableFrom(clazz)) {
-            dispatchers.add(new HttpDeletableDispatcher());
+            dispatchers.add(new HttpDeletable.HttpDeletableDispatcher());
         }
 
         // check action <obj>.do<token>(...) and other WebMethods

--- a/core/src/main/java/org/kohsuke/stapler/Stapler.java
+++ b/core/src/main/java/org/kohsuke/stapler/Stapler.java
@@ -118,7 +118,8 @@ public class Stapler extends HttpServlet {
      */
     private boolean diagnosticThreadName = true;
 
-    public @Override void init(ServletConfig servletConfig) throws ServletException {
+    @Override
+    public void init(ServletConfig servletConfig) throws ServletException {
         super.init(servletConfig);
         this.context = servletConfig.getServletContext();
         this.webApp = WebApp.get(context);
@@ -188,8 +189,8 @@ public class Stapler extends HttpServlet {
         this.webApp = webApp;
     }
 
-    protected @Override void service(HttpServletRequest req, HttpServletResponse rsp)
-            throws ServletException, IOException {
+    @Override
+    protected void service(HttpServletRequest req, HttpServletResponse rsp) throws ServletException, IOException {
         Thread t = Thread.currentThread();
         final String oldName = t.getName();
         try {

--- a/core/src/main/java/org/kohsuke/stapler/StaplerRequest.java
+++ b/core/src/main/java/org/kohsuke/stapler/StaplerRequest.java
@@ -497,11 +497,11 @@ public interface StaplerRequest extends HttpServletRequest {
     /**
      * Obtains a commons-fileupload object that represents an uploaded file.
      *
-     * @deprecated use {@link #getFileItem2(String)}
      * @return
      *      null if a file of the given form field name doesn't exist.
      *      This includes the case where the name corresponds to a simple
      *      form field (like textbox, checkbox, etc.)
+     * @deprecated use {@link #getFileItem2(String)}
      */
     @Deprecated
     org.apache.commons.fileupload.FileItem getFileItem(String name) throws ServletException, IOException;

--- a/core/src/main/java/org/kohsuke/stapler/StaplerResponseWrapper.java
+++ b/core/src/main/java/org/kohsuke/stapler/StaplerResponseWrapper.java
@@ -146,7 +146,9 @@ public abstract class StaplerResponseWrapper implements StaplerResponse {
         getWrapped().serveFile(req, data, lastModified, contentLength, fileName);
     }
 
-    /** {@inheritDoc} */
+    /**
+     * @deprecated Use {@link #serveExposedBean(StaplerRequest, Object, ExportConfig)}
+     */
     @Override
     @Deprecated
     public void serveExposedBean(StaplerRequest req, Object exposedBean, Flavor flavor)

--- a/core/src/main/java/org/kohsuke/stapler/bind/BoundObjectTable.java
+++ b/core/src/main/java/org/kohsuke/stapler/bind/BoundObjectTable.java
@@ -79,11 +79,11 @@ public class BoundObjectTable implements StaplerFallback {
      * This serves the script content for a bound object. Support CSP-compatible st:bind and similar methods of making
      * objects accessible to JS.
      *
-     * @param req
-     * @param rsp
+     * @param req The request
+     * @param rsp The response
      * @param var the variable name to assign the Stapler proxy to
      * @param methods the list of methods (needed for {@link WithWellKnownURL})
-     * @throws IOException
+     * @throws IOException If an I/O error occurs
      */
     public void doScript(
             StaplerRequest req, StaplerResponse rsp, @QueryParameter String var, @QueryParameter String methods)

--- a/core/src/main/java/org/kohsuke/stapler/export/ModelBuilder.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/ModelBuilder.java
@@ -49,8 +49,8 @@ public class ModelBuilder {
     }
 
     /**
-     * @throws NotExportableException if type is not exportable
      * @return model
+     * @throws NotExportableException if type is not exportable
      */
     @NonNull
     public <T> Model<T> get(Class<T> type, @CheckForNull Class<?> propertyOwner, @Nullable String property)

--- a/core/src/main/java/org/kohsuke/stapler/framework/io/IOException2.java
+++ b/core/src/main/java/org/kohsuke/stapler/framework/io/IOException2.java
@@ -25,7 +25,11 @@ package org.kohsuke.stapler.framework.io;
 
 import java.io.IOException;
 
-/** not needed as of Java 6 */
+/**
+ * not needed as of Java 6
+ *
+ * @deprecated use {@link IOException}
+ */
 @Deprecated
 public class IOException2 extends IOException {
     public IOException2() {}

--- a/core/src/test/java/org/kohsuke/stapler/export/XMLDataWriterTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/XMLDataWriterTest.java
@@ -251,7 +251,8 @@ public class XMLDataWriterTest {
     @Test
     public void testToSingularWithPluralProperties() throws Exception {
         assertEquals(
-                "<arraysWithPluralProperties _class='ArraysWithPluralProperties'><bars>foo</bars><category>general</category><category>specific</category><foos>foo</foos><style>ornate</style><style>plain</style></arraysWithPluralProperties>",
+                "<arraysWithPluralProperties _class='ArraysWithPluralProperties'><bars>foo</bars><category>general</category><category>specific</category>"
+                        + "<foos>foo</foos><style>ornate</style><style>plain</style></arraysWithPluralProperties>",
                 serialize(new ArraysWithPluralProperties(), ArraysWithPluralProperties.class));
     }
 }

--- a/core/src/test/java/org/kohsuke/stapler/interceptor/JsonOutputFilterTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/interceptor/JsonOutputFilterTest.java
@@ -93,13 +93,13 @@ public class JsonOutputFilterTest extends JettyTestCase {
         }
     }
 
-    @JsonOutputFilter(excludes = {"secret"})
+    @JsonOutputFilter(excludes = "secret")
     @JavaScriptMethod
     public MyData getSomeExcludedData() {
         return new MyData("Bob", "the builder", "super secret value");
     }
 
-    @JsonOutputFilter(excludes = {"secret"})
+    @JsonOutputFilter(excludes = "secret")
     @JavaScriptMethod
     public List<MyData> getSomeExcludedList() {
         return Arrays.asList(
@@ -108,7 +108,7 @@ public class JsonOutputFilterTest extends JettyTestCase {
                 new MyData("Jenkins", "the butler", "really secret as well"));
     }
 
-    @JsonOutputFilter(includes = {"name"})
+    @JsonOutputFilter(includes = "name")
     @JavaScriptMethod
     public MyData getSomeIncludedData() {
         return new MyData("Bob", "the builder", "super secret value");

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/ConstructorProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/ConstructorProcessorTest.java
@@ -32,7 +32,7 @@ class ConstructorProcessorTest {
                 "import org.kohsuke.stapler.DataBoundConstructor;",
                 "public class Stuff {",
                 "  @DataBoundConstructor public Stuff(int count, String name) {}",
-                "}",
+                "}"
             })
     @Test
     void basicOutput(Results results) {
@@ -67,9 +67,7 @@ class ConstructorProcessorTest {
                 "  @DataBoundConstructor public Stuff(int count, String name) {}",
                 "}"
             })
-    @Inline(
-            name = "some.pkg.package-info",
-            source = {"package some.pkg;"})
+    @Inline(name = "some.pkg.package-info", source = "package some.pkg;")
     @Test
     void JENKINS_11739(Results results) {
         assertEquals(Collections.emptyList(), results.diagnostics);
@@ -179,7 +177,7 @@ class ConstructorProcessorTest {
                 "import org.kohsuke.stapler.DataBoundConstructor;",
                 "public class Stuff {",
                 "  @DataBoundConstructor public Stuff(int count, String name) {}",
-                "}",
+                "}"
             })
     @Test
     void reproducibleBuild(Results results) {

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/ExportedBeanAnnotationProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/ExportedBeanAnnotationProcessorTest.java
@@ -15,10 +15,7 @@ import org.jvnet.hudson.annotation_indexer.AnnotationProcessorImpl;
 
 @ExtendWith(JavacExtension.class)
 @Options("-Werror")
-@Processors({
-    AnnotationProcessorImpl.class,
-    ExportedBeanAnnotationProcessor.class,
-})
+@Processors({AnnotationProcessorImpl.class, ExportedBeanAnnotationProcessor.class})
 class ExportedBeanAnnotationProcessorTest {
 
     private void assertEqualsCRLF(String s1, String s2) {
@@ -83,7 +80,7 @@ class ExportedBeanAnnotationProcessorTest {
                 "import org.kohsuke.stapler.export.*;",
                 "@ExportedBean public abstract class Super {",
                 "  @Exported public abstract int getCount();",
-                "}",
+                "}"
             })
     @Inline(
             name = "some.pkg.Stuff",

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/QueryParameterAnnotationProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/QueryParameterAnnotationProcessorTest.java
@@ -24,7 +24,7 @@ class QueryParameterAnnotationProcessorTest {
                 "public class Stuff {",
                 "  public void doOneThing(@QueryParameter String key) {}",
                 "  public void doAnother(@QueryParameter(\"ignoredHere\") String name, @QueryParameter String address) {}",
-                "}",
+                "}"
             })
     @Test
     void basicOutput(Results results) {

--- a/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/GroovyClassTearOff.java
+++ b/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/GroovyClassTearOff.java
@@ -52,6 +52,8 @@ public final class GroovyClassTearOff
 
     /**
      * Creates a {@link RequestDispatcher} that forwards to the jelly view, if available.
+     *
+     * @deprecated removed without replacement
      */
     @Deprecated
     public RequestDispatcher createDispatcher(Object it, String viewName) throws IOException {

--- a/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/GroovyClosureScript.java
+++ b/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/GroovyClosureScript.java
@@ -63,9 +63,7 @@ import groovy.lang.Script;
 public abstract class GroovyClosureScript extends Script {
     private GroovyObject delegate;
 
-    protected GroovyClosureScript() {
-        super();
-    }
+    protected GroovyClosureScript() {}
 
     protected GroovyClosureScript(Binding binding) {
         super(binding);

--- a/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/GroovyServerPageTearOff.java
+++ b/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/GroovyServerPageTearOff.java
@@ -32,6 +32,8 @@ public class GroovyServerPageTearOff
 
     /**
      * Creates a {@link RequestDispatcher} that forwards to the jelly view, if available.
+     *
+     * @deprecated removed without replacement
      */
     @Deprecated
     public RequestDispatcher createDispatcher(Object it, String viewName) throws IOException {

--- a/jelly/src/main/java/org/kohsuke/stapler/framework/adjunct/Adjunct.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/framework/adjunct/Adjunct.java
@@ -195,8 +195,9 @@ public class Adjunct {
                 return hasCss;
             case JS:
                 return hasJavaScript;
+            default:
+                throw new IllegalArgumentException("Unknown Kind: " + k);
         }
-        throw new AssertionError(k);
     }
 
     public void write(StaplerRequest req, XMLOutput out) throws SAXException, IOException {

--- a/jelly/src/main/java/org/kohsuke/stapler/framework/adjunct/NoSuchAdjunctException.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/framework/adjunct/NoSuchAdjunctException.java
@@ -41,7 +41,6 @@ public class NoSuchAdjunctException extends IOException {
     }
 
     public NoSuchAdjunctException(Throwable cause) {
-        super();
         initCause(cause);
     }
 }

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/InternationalizedStringExpression.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/InternationalizedStringExpression.java
@@ -23,7 +23,6 @@
 
 package org.kohsuke.stapler.jelly;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.jelly.JellyContext;
@@ -94,7 +93,6 @@ public class InternationalizedStringExpression extends ExpressionSupport {
      * Note: this code is also copied into idea-stapler-plugin,
      * so don't forget to update that when this code changes.
      */
-    @SuppressFBWarnings(value = "SF_SWITCH_NO_DEFAULT", justification = "No default needed.")
     private String tokenize(String text) throws JellyException {
         int parenthesis = 0;
         for (int idx = 0; idx < text.length(); idx++) {
@@ -123,6 +121,8 @@ public class InternationalizedStringExpression extends ExpressionSupport {
                 case '\'':
                     // skip strings
                     idx = text.indexOf(ch, idx + 1);
+                    break;
+                default:
                     break;
             }
         }

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyClassTearOff.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyClassTearOff.java
@@ -98,6 +98,8 @@ public class JellyClassTearOff extends AbstractTearOff<JellyClassLoaderTearOff, 
 
     /**
      * Serves {@code index.jelly} if it's available, and returns true.
+     *
+     * @deprecated removed without replacement
      */
     @Deprecated
     public boolean serveIndexJelly(StaplerRequest req, StaplerResponse rsp, Object node)
@@ -125,6 +127,8 @@ public class JellyClassTearOff extends AbstractTearOff<JellyClassLoaderTearOff, 
 
     /**
      * Creates a {@link RequestDispatcher} that forwards to the jelly view, if available.
+     *
+     * @deprecated removed without replacement
      */
     @Deprecated
     public RequestDispatcher createDispatcher(Object it, String viewName) throws IOException {

--- a/jsp/src/main/java/org/kohsuke/stapler/tags/Include.java
+++ b/jsp/src/main/java/org/kohsuke/stapler/tags/Include.java
@@ -134,18 +134,18 @@ public class Include extends SimpleTagSupport {
 
         throw new JspException("Unable to find '" + page + "' for " + it.getClass());
     }
-}
 
-class Wrapper extends HttpServletResponseWrapper {
-    private final PrintWriter pw;
+    static class Wrapper extends HttpServletResponseWrapper {
+        private final PrintWriter pw;
 
-    Wrapper(HttpServletResponse httpServletResponse, PrintWriter w) {
-        super(httpServletResponse);
-        this.pw = w;
-    }
+        Wrapper(HttpServletResponse httpServletResponse, PrintWriter w) {
+            super(httpServletResponse);
+            this.pw = w;
+        }
 
-    @Override
-    public PrintWriter getWriter() throws IOException {
-        return pw;
+        @Override
+        public PrintWriter getWriter() throws IOException {
+            return pw;
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,32 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <!-- Version specified in parent POM -->
+          <configuration>
+            <consoleOutput>true</consoleOutput>
+            <includeTestSourceDirectory>true</includeTestSourceDirectory>
+            <configLocation>${maven.multiModuleProjectDirectory}/src/checkstyle/checkstyle-configuration.xml</configLocation>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>10.16.0</version>
+            </dependency>
+          </dependencies>
+          <executions>
+            <execution>
+              <id>validate</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <phase>validate</phase>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>animal-sniffer-maven-plugin</artifactId>
           <configuration>
@@ -117,5 +143,12 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <!-- Version specified in parent POM -->
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/src/checkstyle/checkstyle-configuration.xml
+++ b/src/checkstyle/checkstyle-configuration.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="UniqueProperties"/>
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+  <module name="LineLength">
+    <property name="fileExtensions" value="java"/>
+    <property name="max" value="240"/>
+    <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+  </module>
+  <module name="TreeWalker">
+    <!--
+      Annotations: https://checkstyle.sourceforge.io/config_annotation.html
+    -->
+    <module name="AnnotationUseStyle"/>
+    <module name="MissingDeprecated"/>
+    <module name="MissingOverride"/>
+    <!--
+      Class Design: https://checkstyle.sourceforge.io/config_design.html
+    -->
+    <module name="OneTopLevelClass"/>
+    <!--
+      Coding: https://checkstyle.sourceforge.io/config_coding.html
+    -->
+    <module name="ArrayTrailingComma"/>
+    <module name="AvoidNoArgumentSuperConstructorCall"/>
+    <module name="CovariantEquals"/>
+    <module name="DefaultComesLast"/>
+    <module name="EqualsHashCode"/>
+    <module name="MissingSwitchDefault"/>
+    <module name="NoEnumTrailingComma"/>
+    <module name="OneStatementPerLine"/>
+    <module name="PackageDeclaration"/>
+    <module name="RequireThis"/>
+    <module name="SimplifyBooleanExpression"/>
+    <module name="StringLiteralEquality"/>
+    <module name="SuperClone"/>
+    <module name="SuperFinalize"/>
+    <module name="UnnecessarySemicolonAfterOuterTypeDeclaration"/>
+    <module name="UnnecessarySemicolonAfterTypeMemberDeclaration"/>
+    <module name="UnnecessarySemicolonInEnumeration"/>
+    <module name="UnnecessarySemicolonInTryWithResources"/>
+    <module name="VariableDeclarationUsageDistance">
+      <property name="allowedDistance" value="10"/>
+    </module>
+    <!--
+      Imports: https://checkstyle.sourceforge.io/config_imports.html
+    -->
+    <module name="AvoidStarImport"/>
+    <module name="CustomImportOrder">
+      <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+      <property name="sortImportsInGroupAlphabetically" value="true"/>
+      <property name="separateLineBetweenGroups" value="true"/>
+    </module>
+    <module name="IllegalImport">
+      <!-- prevent the use of jsr-305 annotations and Spring utilities -->
+      <property name="illegalClasses" value="javax.annotation.MatchesPattern.Checker, javax.annotation.Nonnegative.Checker, javax.annotation.Nonnull.Checker, javax.annotation.RegEx.Checker, javax.annotation.CheckForNull, javax.annotation.CheckForSigned, javax.annotation.CheckReturnValue, javax.annotation.Detainted, javax.annotation.MatchesPattern, javax.annotation.Nonnegative, javax.annotation.Nonnull, javax.annotation.Nullable, javax.annotation.OverridingMethodsMustInvokeSuper, javax.annotation.ParametersAreNonnullByDefault, javax.annotation.ParametersAreNullableByDefault, javax.annotation.PropertyKey, javax.annotation.RegEx, javax.annotation.Signed, javax.annotation.Syntax, javax.annotation.Tainted, javax.annotation.Untainted, javax.annotation.WillClose, javax.annotation.WillCloseWhenClosed, javax.annotation.WillNotClose, javax.annotation.concurrent.GuardedBy, javax.annotation.concurrent.Immutable, javax.annotation.concurrent.NotThreadSafe, javax.annotation.concurrent.ThreadSafe, javax.annotation.meta.TypeQualifierValidator, javax.annotation.meta.When, javax.annotation.meta.Exclusive, javax.annotation.meta.Exhaustive, javax.annotation.meta.TypeQualifier, javax.annotation.meta.TypeQualifierDefault, javax.annotation.meta.TypeQualifierNickname, org.apache.log4j.Logger, org.springframework.util.Assert, org.springframework.util.StringUtils"/>
+      <!-- Prevent the expansion of Guava usages and ban internal library packages -->
+      <property name="illegalPkgs" value="com.google.common.base, com.google.common.eventbus, com.google.common.graph, com.google.common.hash, com.google.common.html, com.google.common.io, com.google.common.math, com.google.common.net, com.google.common.reflect, com.google.common.xml, com.google.thirdparty, jline.internal"/>
+    </module>
+    <module name="RedundantImport"/>
+    <module name="UnusedImports"/>
+    <!--
+      Javadoc Comments: https://checkstyle.sourceforge.io/config_javadoc.html
+    -->
+    <module name="AtclauseOrder">
+      <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+    </module>
+    <module name="InvalidJavadocPosition"/>
+    <module name="JavadocMethod">
+      <property name="allowedAnnotations" value="Override, Test"/>
+      <property name="allowMissingParamTags" value="true"/>
+      <property name="allowMissingReturnTag" value="true"/>
+    </module>
+    <module name="JavadocMissingWhitespaceAfterAsterisk"/>
+    <module name="NonEmptyAtclauseDescription"/>
+    <!--
+      Miscellaneous: https://checkstyle.sourceforge.io/config_misc.html
+    -->
+    <module name="ArrayTypeStyle"/>
+    <module name="OuterTypeFilename"/>
+    <module name="UpperEll"/>
+    <!--
+      Modifiers: https://checkstyle.sourceforge.io/config_modifier.html
+    -->
+    <module name="ModifierOrder"/>
+    <module name="RedundantModifier"/>
+    <!--
+      Regexp: https://checkstyle.sourceforge.io/config_regexp.html
+    -->
+    <module name="Regexp">
+      <property name="format" value="[ \t]+$"/>
+      <property name="illegalPattern" value="true"/>
+      <property name="message" value="Trailing whitespace"/>
+    </module>
+    <!--
+      Whitespace: https://checkstyle.sourceforge.io/config_whitespace.html
+    -->
+    <module name="EmptyLineSeparator">
+      <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF, STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF"/>
+      <property name="allowNoEmptyLineBetweenFields" value="true"/>
+    </module>
+    <module name="GenericWhitespace">
+      <message key="ws.followed" value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+      <message key="ws.preceded" value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+      <message key="ws.illegalFollow" value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+      <message key="ws.notPreceded" value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+    </module>
+    <module name="MethodParamPad">
+      <property name="tokens" value="CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF, SUPER_CTOR_CALL, ENUM_CONSTANT_DEF, RECORD_DEF"/>
+    </module>
+    <module name="NoLineWrap">
+      <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT"/>
+    </module>
+    <module name="NoWhitespaceBefore">
+      <property name="tokens" value="COMMA, SEMI, POST_INC, POST_DEC, DOT, LABELED_STAT, METHOD_REF"/>
+      <property name="allowLineBreaks" value="true"/>
+    </module>
+    <module name="NoWhitespaceBeforeCaseDefaultColon"/>
+    <module name="ParenPad">
+      <property name="tokens" value="ANNOTATION, ANNOTATION_FIELD_DEF, CTOR_CALL, CTOR_DEF, DOT, ENUM_CONSTANT_DEF, EXPR, LITERAL_CATCH, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_NEW, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_WHILE, METHOD_CALL, METHOD_DEF, QUESTION, RESOURCE_SPECIFICATION, SUPER_CTOR_CALL, LAMBDA, RECORD_DEF"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapComma"/>
+      <property name="tokens" value="COMMA"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapMethodRef"/>
+      <property name="tokens" value="METHOD_REF"/>
+      <property name="option" value="nl"/>
+    </module>
+    <module name="WhitespaceAfter">
+      <property name="tokens" value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE, LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, DO_WHILE"/>
+    </module>
+    <module name="WhitespaceAround">
+      <property name="allowEmptyConstructors" value="true"/>
+      <property name="allowEmptyLambdas" value="true"/>
+      <property name="allowEmptyMethods" value="true"/>
+      <property name="allowEmptyTypes" value="true"/>
+      <property name="allowEmptyLoops" value="true"/>
+      <property name="ignoreEnhancedForColon" value="false"/>
+      <property name="tokens" value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR, SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND"/>
+      <message key="ws.notFollowed" value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+      <message key="ws.notPreceded" value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+    </module>
+  </module>
+</module>


### PR DESCRIPTION
Enable Checkstyle with the same set of rules used in Jenkins core. This makes the two repositories more consistent and makes it easier to go back and forth reading code between these repositories.

### Testing done

`mvn clean verify`