### PR TITLE
Deprecate `WebApp#mimeTypes`

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/Stapler.java
+++ b/core/src/main/java/org/kohsuke/stapler/Stapler.java
@@ -675,11 +675,7 @@ public class Stapler extends HttpServlet {
         idx = fileName.lastIndexOf('\\');
         fileName = fileName.substring(idx + 1);
 
-        String extension = fileName.substring(fileName.lastIndexOf('.') + 1);
-        String mimeType = webApp.mimeTypes.get(extension);
-        if (mimeType == null) {
-            mimeType = getServletContext().getMimeType(fileName);
-        }
+        String mimeType = getServletContext().getMimeType(fileName);
         if (mimeType == null) {
             mimeType = "application/octet-stream";
         }

--- a/core/src/main/java/org/kohsuke/stapler/WebApp.java
+++ b/core/src/main/java/org/kohsuke/stapler/WebApp.java
@@ -111,7 +111,10 @@ public class WebApp {
      *
      * This overrides whatever mappings given in the servlet as far as stapler is concerned.
      * This is case insensitive, and should be normalized to lower case.
+     *
+     * @deprecated removed without replacement
      */
+    @Deprecated
     public final Map<String, String> mimeTypes = new Hashtable<>();
 
     private volatile ClassLoader classLoader;


### PR DESCRIPTION
In practice this map is always empty, since I checked Jenkins and CloudBees sources and nothing ever writes to the map. The only reader besides Stapler is https://github.com/jenkinsci/scm-api-plugin/blob/a24e62fa67977d1c381b922a1a745afb725771c7/src/main/java/jenkins/scm/api/SCMFile.java#L422. Altogether I can't see a good reason to retain this feature; the servlet container should always be the source of truth and this seems like yet another case of Stapler over-reaching in scope. Simpler to deprecate this feature and remove it eventually.

### Testing done

`mvn clean verify`

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
