### PR TITLE
Improve debugging support for annotation processors

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/jsr269/AbstractProcessorImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/jsr269/AbstractProcessorImpl.java
@@ -63,9 +63,7 @@ abstract class AbstractProcessorImpl extends AbstractProcessor {
     }
 
     protected void notice(String msg, Element location) {
-        // IntelliJ flags this as an error. So disabling it for now.
-        // See http://youtrack.jetbrains.net/issue/IDEA-71822
-        // processingEnv.getMessager().printMessage(NOTE, msg, location);
+        processingEnv.getMessager().printMessage(Kind.NOTE, msg, location);
     }
 
     protected void writePropertyFile(Properties p, String name) throws IOException {

--- a/core/src/main/java/org/kohsuke/stapler/jsr269/QueryParameterAnnotationProcessor.java
+++ b/core/src/main/java/org/kohsuke/stapler/jsr269/QueryParameterAnnotationProcessor.java
@@ -69,9 +69,9 @@ public class QueryParameterAnnotationProcessor extends AbstractProcessorImpl {
         }
 
         TypeElement t = (TypeElement) m.getEnclosingElement();
-        FileObject f = createResource(
-                t.getQualifiedName().toString().replace('.', '/') + "/" + m.getSimpleName() + ".stapler");
-        notice("Generating " + f, m);
+        String name = t.getQualifiedName().toString().replace('.', '/') + "/" + m.getSimpleName() + ".stapler";
+        FileObject f = createResource(name);
+        notice("Generating " + name, m);
 
         try (OutputStream os = f.openOutputStream()) {
             os.write(buf.toString().getBytes(StandardCharsets.UTF_8));

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/ConstructorProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/ConstructorProcessorTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.karuslabs.elementary.Results;
 import com.karuslabs.elementary.junit.JavacExtension;
@@ -12,11 +11,9 @@ import com.karuslabs.elementary.junit.annotations.Inline;
 import com.karuslabs.elementary.junit.annotations.Options;
 import com.karuslabs.elementary.junit.annotations.Processors;
 import java.time.Year;
-import java.util.Collections;
-import java.util.List;
 import java.util.Locale;
-import javax.tools.Diagnostic;
-import javax.tools.JavaFileObject;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -36,7 +33,10 @@ class ConstructorProcessorTest {
             })
     @Test
     void basicOutput(Results results) {
-        assertEquals(Collections.emptyList(), results.diagnostics);
+        Set<String> diagnostics = results.diagnostics.stream()
+                .map(d -> d.getMessage(Locale.ENGLISH))
+                .collect(Collectors.toSet());
+        assertEquals(Set.of("Generating some/pkg/Stuff.stapler"), diagnostics);
         assertEquals(
                 "{constructor=count,name}",
                 Utils.normalizeProperties(Utils.getGeneratedResource(results.sources, "some/pkg/Stuff.stapler")));
@@ -52,7 +52,10 @@ class ConstructorProcessorTest {
             })
     @Test
     void preAnnotationCompatibility(Results results) {
-        assertEquals(Collections.emptyList(), results.diagnostics);
+        Set<String> diagnostics = results.diagnostics.stream()
+                .map(d -> d.getMessage(Locale.ENGLISH))
+                .collect(Collectors.toSet());
+        assertEquals(Set.of("Generating some/pkg/Stuff.stapler"), diagnostics);
         assertEquals(
                 "{constructor=name,count}",
                 Utils.normalizeProperties(Utils.getGeneratedResource(results.sources, "some/pkg/Stuff.stapler")));
@@ -70,7 +73,10 @@ class ConstructorProcessorTest {
     @Inline(name = "some.pkg.package-info", source = "package some.pkg;")
     @Test
     void JENKINS_11739(Results results) {
-        assertEquals(Collections.emptyList(), results.diagnostics);
+        Set<String> diagnostics = results.diagnostics.stream()
+                .map(d -> d.getMessage(Locale.ENGLISH))
+                .collect(Collectors.toSet());
+        assertEquals(Set.of("Generating some/pkg/Stuff.stapler"), diagnostics);
         assertEquals(
                 "{constructor=count,name}",
                 Utils.normalizeProperties(Utils.getGeneratedResource(results.sources, "some/pkg/Stuff.stapler")));
@@ -87,10 +93,10 @@ class ConstructorProcessorTest {
             })
     @Test
     void privateConstructor(Results results) {
-        List<Diagnostic<? extends JavaFileObject>> diagnostics = results.diagnostics;
-        assertEquals(1, diagnostics.size());
-        String msg = diagnostics.get(0).getMessage(Locale.ENGLISH);
-        assertTrue(msg.contains("public"), msg);
+        Set<String> diagnostics = results.diagnostics.stream()
+                .map(d -> d.getMessage(Locale.ENGLISH))
+                .collect(Collectors.toSet());
+        assertEquals(Set.of("@DataBoundConstructor must be applied to a public constructor"), diagnostics);
     }
 
     @Inline(
@@ -104,10 +110,12 @@ class ConstructorProcessorTest {
             })
     @Test
     void abstractClass(Results results) {
-        List<Diagnostic<? extends JavaFileObject>> diagnostics = results.diagnostics;
-        assertEquals(1, diagnostics.size());
-        String msg = diagnostics.get(0).getMessage(Locale.ENGLISH);
-        assertTrue(msg.contains("abstract"), msg);
+        Set<String> diagnostics = results.diagnostics.stream()
+                .map(d -> d.getMessage(Locale.ENGLISH))
+                .collect(Collectors.toSet());
+        assertEquals(
+                Set.of("@DataBoundConstructor may not be used on an abstract class (only on concrete subclasses)"),
+                diagnostics);
     }
 
     // issue-179
@@ -123,10 +131,10 @@ class ConstructorProcessorTest {
             })
     @Test
     void duplicatedConstructor1(Results results) {
-        List<Diagnostic<? extends JavaFileObject>> diagnostics = results.diagnostics;
-        assertEquals(1, diagnostics.size());
-        String msg = diagnostics.get(0).getMessage(Locale.ENGLISH);
-        assertTrue(msg.contains(ConstructorProcessor.MESSAGE), msg);
+        Set<String> diagnostics = results.diagnostics.stream()
+                .map(d -> d.getMessage(Locale.ENGLISH))
+                .collect(Collectors.toSet());
+        assertEquals(Set.of("Generating some/pkg/Stuff.stapler", ConstructorProcessor.MESSAGE), diagnostics);
     }
 
     // issue-179
@@ -145,10 +153,10 @@ class ConstructorProcessorTest {
             })
     @Test
     void duplicatedConstructor2(Results results) {
-        List<Diagnostic<? extends JavaFileObject>> diagnostics = results.diagnostics;
-        assertEquals(1, diagnostics.size());
-        String msg = diagnostics.get(0).getMessage(Locale.ENGLISH);
-        assertTrue(msg.contains(ConstructorProcessor.MESSAGE), msg);
+        Set<String> diagnostics = results.diagnostics.stream()
+                .map(d -> d.getMessage(Locale.ENGLISH))
+                .collect(Collectors.toSet());
+        assertEquals(Set.of("Generating some/pkg/Stuff.stapler", ConstructorProcessor.MESSAGE), diagnostics);
     }
 
     // issue-179
@@ -164,8 +172,10 @@ class ConstructorProcessorTest {
             })
     @Test
     void duplicatedButNotAnnotatedConstructor(Results results) {
-        List<Diagnostic<? extends JavaFileObject>> diagnostics = results.diagnostics;
-        assertEquals(0, diagnostics.size());
+        Set<String> diagnostics = results.diagnostics.stream()
+                .map(d -> d.getMessage(Locale.ENGLISH))
+                .collect(Collectors.toSet());
+        assertEquals(Set.of("Generating some/pkg/Stuff.stapler"), diagnostics);
     }
     // TODO nested classes use qualified rather than binary name
 
@@ -181,7 +191,10 @@ class ConstructorProcessorTest {
             })
     @Test
     void reproducibleBuild(Results results) {
-        assertEquals(Collections.emptyList(), results.diagnostics);
+        Set<String> diagnostics = results.diagnostics.stream()
+                .map(d -> d.getMessage(Locale.ENGLISH))
+                .collect(Collectors.toSet());
+        assertEquals(Set.of("Generating some/pkg/Stuff.stapler"), diagnostics);
         assertThat(
                 Utils.getGeneratedResource(results.sources, "some/pkg/Stuff.stapler"),
                 not(containsString(Integer.toString(Year.now().getValue()))));

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/ExportedBeanAnnotationProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/ExportedBeanAnnotationProcessorTest.java
@@ -8,7 +8,9 @@ import com.karuslabs.elementary.junit.JavacExtension;
 import com.karuslabs.elementary.junit.annotations.Inline;
 import com.karuslabs.elementary.junit.annotations.Options;
 import com.karuslabs.elementary.junit.annotations.Processors;
-import java.util.Collections;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jvnet.hudson.annotation_indexer.AnnotationProcessorImpl;
@@ -36,7 +38,10 @@ class ExportedBeanAnnotationProcessorTest {
             })
     @Test
     void basicOutput(Results results) {
-        assertEquals(Collections.emptyList(), results.diagnostics);
+        Set<String> diagnostics = results.diagnostics.stream()
+                .map(d -> d.getMessage(Locale.ENGLISH))
+                .collect(Collectors.toSet());
+        assertEquals(Set.of("Generating some/pkg/Stuff.javadoc"), diagnostics);
         assertEqualsCRLF(
                 "some.pkg.Stuff\n",
                 Utils.getGeneratedResource(
@@ -60,7 +65,10 @@ class ExportedBeanAnnotationProcessorTest {
             })
     @Test
     void noJavadoc(Results results) {
-        assertEquals(Collections.emptyList(), results.diagnostics);
+        Set<String> diagnostics = results.diagnostics.stream()
+                .map(d -> d.getMessage(Locale.ENGLISH))
+                .collect(Collectors.toSet());
+        assertEquals(Set.of("Generating some/pkg/Stuff.javadoc"), diagnostics);
         assertEqualsCRLF(
                 "some.pkg.Stuff\n",
                 Utils.getGeneratedResource(
@@ -93,7 +101,10 @@ class ExportedBeanAnnotationProcessorTest {
             })
     @Test
     void subclassOfExportedBean(Results results) {
-        assertEquals(Collections.emptyList(), results.diagnostics);
+        Set<String> diagnostics = results.diagnostics.stream()
+                .map(d -> d.getMessage(Locale.ENGLISH))
+                .collect(Collectors.toSet());
+        assertEquals(Set.of("Generating some/pkg/Super.javadoc"), diagnostics);
         /* #7188605: broken in JDK 6u33 + org.jvnet.hudson:annotation-indexer:1.2:
         assertEquals("some.pkg.Stuff\n", Utils.getGeneratedResource(results.sources, "META-INF/services/annotations/org.kohsuke.stapler.export.ExportedBean"));
         */
@@ -125,7 +136,10 @@ class ExportedBeanAnnotationProcessorTest {
             })
     @Test
     void multiple(Results results) {
-        assertEquals(Collections.emptyList(), results.diagnostics);
+        Set<String> diagnostics = results.diagnostics.stream()
+                .map(d -> d.getMessage(Locale.ENGLISH))
+                .collect(Collectors.toSet());
+        assertEquals(Set.of("Generating some/pkg/Stuff.javadoc", "Generating some/pkg/MoreStuff.javadoc"), diagnostics);
         assertEqualsCRLF(
                 "some.pkg.MoreStuff\nsome.pkg.Stuff\n",
                 Utils.getGeneratedResource(

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/QueryParameterAnnotationProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/QueryParameterAnnotationProcessorTest.java
@@ -7,7 +7,9 @@ import com.karuslabs.elementary.junit.JavacExtension;
 import com.karuslabs.elementary.junit.annotations.Inline;
 import com.karuslabs.elementary.junit.annotations.Options;
 import com.karuslabs.elementary.junit.annotations.Processors;
-import java.util.Collections;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -28,7 +30,12 @@ class QueryParameterAnnotationProcessorTest {
             })
     @Test
     void basicOutput(Results results) {
-        assertEquals(Collections.emptyList(), results.diagnostics);
+        Set<String> diagnostics = results.diagnostics.stream()
+                .map(d -> d.getMessage(Locale.ENGLISH))
+                .collect(Collectors.toSet());
+        assertEquals(
+                Set.of("Generating some/pkg/Stuff/doOneThing.stapler", "Generating some/pkg/Stuff/doAnother.stapler"),
+                diagnostics);
         assertEquals("key", Utils.getGeneratedResource(results.sources, "some/pkg/Stuff/doOneThing.stapler"));
         assertEquals("name,address", Utils.getGeneratedResource(results.sources, "some/pkg/Stuff/doAnother.stapler"));
     }


### PR DESCRIPTION
While recently attempting to debug an annotation processor, I found that all notices were being discarded, apparently due to an [IntelliJ issue](http://youtrack.jetbrains.net/issue/IDEA-71822) from 13 years ago that appears to have been resolved since then. This PR re-enables logging of notices and adapts the tests to expect them.

### Testing done

`mvn clean verify`