### PR TITLE
Undocumented NPE if `Stapler.getCurrent()` called outside an HTTP handling thread

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/Stapler.java
+++ b/core/src/main/java/org/kohsuke/stapler/Stapler.java
@@ -1048,6 +1048,7 @@ public class Stapler extends HttpServlet {
 
     /**
      * Gets the current {@link StaplerRequest2} that the calling thread is associated with.
+     * @return null, if called from outside an HTTP handling thread
      */
     public static StaplerRequest2 getCurrentRequest2() {
         return CURRENT_REQUEST.get();
@@ -1064,6 +1065,7 @@ public class Stapler extends HttpServlet {
 
     /**
      * Gets the current {@link StaplerResponse2} that the calling thread is associated with.
+     * @return null, if called from outside an HTTP handling thread
      */
     public static StaplerResponse2 getCurrentResponse2() {
         return CURRENT_RESPONSE.get();
@@ -1080,9 +1082,11 @@ public class Stapler extends HttpServlet {
 
     /**
      * Gets the current {@link Stapler} that the calling thread is associated with.
+     * @return null, if called from outside an HTTP handling thread
      */
     public static Stapler getCurrent() {
-        return CURRENT_REQUEST.get().getStapler();
+        var req = CURRENT_REQUEST.get();
+        return req != null ? req.getStapler() : null;
     }
 
     /**

--- a/core/src/test/java/org/kohsuke/stapler/StaplerTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/StaplerTest.java
@@ -95,5 +95,4 @@ public class StaplerTest extends TestCase {
     public void testGetCurrent() throws Exception {
         assertNull("may be called outside an HTTP handling thread", Stapler.getCurrent());
     }
-
 }

--- a/core/src/test/java/org/kohsuke/stapler/StaplerTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/StaplerTest.java
@@ -91,4 +91,9 @@ public class StaplerTest extends TestCase {
                     new URL("file:/tmp/" + path));
         }
     }
+
+    public void testGetCurrent() throws Exception {
+        assertNull("may be called outside an HTTP handling thread", Stapler.getCurrent());
+    }
+
 }


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/blob/e1a6b190d4d71e95a8e00facd52ce7718909b9e8/core/src/main/java/hudson/model/TopLevelItemDescriptor.java#L146-L175 seems to assume this method can be called safely and return null. (I tried to write an integration test but every `TopLevelItemDescriptor` subclass seems to override this method.) https://github.com/jenkinsci/support-core-plugin/blob/a85622b87b52a0ebaf3ecf97c7a443df546e4242/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java#L507-L517 notes the poor behavior.