### PR TITLE
Emit Jelly file inside <script> tags

### DIFF
--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/ReallyStaticTagLibrary.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/ReallyStaticTagLibrary.java
@@ -24,6 +24,8 @@
 package org.kohsuke.stapler.jelly;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.IOException;
+import java.io.Writer;
 import org.apache.commons.jelly.JellyContext;
 import org.apache.commons.jelly.JellyException;
 import org.apache.commons.jelly.JellyTagException;
@@ -99,6 +101,13 @@ public class ReallyStaticTagLibrary extends TagLibrary {
 
                 try {
                     output.startElement(getNsUri(), getLocalName(), getElementName(), actual);
+                    if (getElementName().equals("script")) {
+                        try(Writer writer = output.asWriter()) {
+                            writer.append("/*").append(getFileName().substring(getFileName().length() - 33)).append(":").append(String.valueOf(getLineNumber())).append("*/\n");
+                        } catch (IOException e) {
+                            throw new JellyTagException(e);
+                        }
+                    }
                     getTagBody().run(context, output);
                     output.endElement(getNsUri(), getLocalName(), getElementName());
                 } catch (SAXException x) {


### PR DESCRIPTION
PoC quality: This currently makes empty-bodied `<script>` tags into CSP violations.

WDYT? Worth pursuing?

### Testing done

> <img width="348" alt="Screenshot 2024-11-27 at 00 00 22" src="https://github.com/user-attachments/assets/5d66267e-2cf5-40cc-9252-3a179f6a7edb">


### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
