### PR TITLE
Add a utility method parseAsTreeMap in NamedPathPruner

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/export/NamedPathPruner.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/NamedPathPruner.java
@@ -211,4 +211,44 @@ public final class NamedPathPruner extends TreePruner {
     public @Override Range getRange() {
         return tree.range;
     }
+
+    /**
+     * Parses the given specification and returns a hierarchical tree representation.
+     * <p>
+     * Each node is represented as a key-value pair in the returned {@code TreeMap}.
+     * The value for a key:
+     * <ul>
+     *   <li>Is another {@code TreeMap<String, Object>} for non-leaf nodes.</li>
+     *   <li>Is an empty {@code TreeMap<String, Object>} for leaf nodes.</li>
+     * </ul>
+     *
+     * @param spec the textual specification
+     * @return a hierarchical tree represented as {@code TreeMap<String, Object>}.
+     */
+    public static TreeMap<String, Object> parseAsTreeMap(String spec) {
+        Tree root = parse(spec);
+        return toTreeMapRepresentation(root);
+    }
+
+    /**
+     * Recursively converts the internal {@code Tree} structure into a {@code TreeMap<String, Object>}.
+     * <p>
+     * Leaf nodes are represented by an empty {@code TreeMap} (e.g., {@code new TreeMap<String, Object>()}).
+     *
+     * @param tree the internal {@code Tree} structure to convert
+     * @return a {@code TreeMap<String, Object>} representing the tree
+     */
+    private static TreeMap<String, Object> toTreeMapRepresentation(Tree tree) {
+        TreeMap<String, Object> result = new TreeMap<>();
+
+        for (Map.Entry<String, Tree> entry : tree.children.entrySet()) {
+            String key = entry.getKey();
+            Tree childTree = entry.getValue();
+            TreeMap<String, ?> subtree =
+                    childTree.children.isEmpty() ? new TreeMap<>() : toTreeMapRepresentation(childTree);
+            result.put(key, subtree);
+        }
+
+        return result;
+    }
 }


### PR DESCRIPTION
Currently converting a given tree specification into the `NamedPathPruner.Tree` parsing logic is present only the `NamedPathPruner` class and not exposed to outside. The parsed value `tree` and it's `children` are also not exposed outside (imo, it is done from an encapsulation standpoint, which is correct).

I have a use cases, I would like to parse the give tree spec, just need the list of keys. Although it would be possible
* either - write a usecase specific parsing logic based on delimiters like `, [ ]`, but it will lead to logical mismatch between the parsing logic here and the one implemented for a specific use case.
* or - use reflection and access the `children` of the `tree`, it is not good.

To expose the parsing logic, merely changing the access specifier of methods related to parsing (`parse`, `list`, `node` etc.) or exposing the parsed value by getter - `getTree` or `getChildren` would break the encapsulation and may lead to problems in the downstream code.

This PR proposes to add a utility method without modifying any access specifier or changing state related logic.

I have considered alternatives such as,
* adding a new utility class such as `NamedPathPrunerUtil` to expose the functionality
* and, trying to extend the into child class (but needs to make the `NamedPathPruner` non-`final`)
but this proposed solution seems better one.

### Testing done

* Added automated test, ensured it is running and covers 100% line coverage for the new code.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
