### PR TITLE
[JENKINS-70756] Incorrect `RequestImpl.getParameterMap`

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
@@ -259,17 +259,29 @@ public class RequestImpl extends HttpServletRequestWrapper implements StaplerReq
     }
 
     @Override
-    public Map getParameterMap() {
-        Map parameterMap = super.getParameterMap();
+    public Map<String, String[]> getParameterMap() {
+        var parameterMap = super.getParameterMap();
         if (isMultipart()) {
             Map<String, String> data = getFormDataFormFields();
-            parameterMap.putAll(data);
+            parameterMap = new HashMap<>(parameterMap);
+            for (var e : data.entrySet()) {
+                var values = parameterMap.get(e.getKey());
+                if (values == null) {
+                    values = new String[] {e.getValue()};
+                } else {
+                    int len = values.length;
+                    var moreValues = Arrays.copyOf(values, len + 1);
+                    moreValues[len] = e.getValue();
+                    values = moreValues;
+                }
+                parameterMap.put(e.getKey(), values);
+            }
         }
         return parameterMap;
     }
 
     @Override
-    public Enumeration getParameterNames() {
+    public Enumeration<String> getParameterNames() {
         if (!isMultipart()) {
             return super.getParameterNames();
         }

--- a/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
@@ -276,6 +276,7 @@ public class RequestImpl extends HttpServletRequestWrapper implements StaplerReq
                 }
                 parameterMap.put(e.getKey(), values);
             }
+            parameterMap = Collections.unmodifiableMap(parameterMap);
         }
         return parameterMap;
     }

--- a/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
@@ -77,8 +77,8 @@ public class DataBindingTest extends TestCase {
                 return "text/html";
             }
         };
-        mr.getParameterMap().put("a", "123");
-        mr.getParameterMap().put("b", "string");
+        mr.parameters.put("a", "123");
+        mr.parameters.put("b", "string");
         RequestImpl req = new RequestImpl(new Stapler(), mr, Collections.emptyList(), null);
         new Function.InstanceFunction(
                         getClass().getMethod("doFromStaplerMethod", StaplerRequest2.class, int.class, Binder.class))

--- a/core/src/test/java/org/kohsuke/stapler/MockRequest.java
+++ b/core/src/test/java/org/kohsuke/stapler/MockRequest.java
@@ -19,10 +19,12 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.Principal;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -53,13 +55,13 @@ public class MockRequest implements HttpServletRequest {
     }
 
     @Override
-    public Enumeration getHeaders(String name) {
+    public Enumeration<String> getHeaders(String name) {
         // TODO
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Enumeration getHeaderNames() {
+    public Enumeration<String> getHeaderNames() {
         // TODO
         throw new UnsupportedOperationException();
     }
@@ -184,7 +186,7 @@ public class MockRequest implements HttpServletRequest {
     }
 
     @Override
-    public Enumeration getAttributeNames() {
+    public Enumeration<String> getAttributeNames() {
         // TODO
         throw new UnsupportedOperationException();
     }
@@ -222,18 +224,17 @@ public class MockRequest implements HttpServletRequest {
     public Map<String, String> parameters = new HashMap<>();
 
     @Override
-    public String getParameter(String name) {
+    public final String getParameter(String name) {
         return parameters.get(name);
     }
 
     @Override
-    public Enumeration getParameterNames() {
-        // TODO
-        throw new UnsupportedOperationException();
+    public final Enumeration<String> getParameterNames() {
+        return Collections.enumeration(parameters.keySet());
     }
 
     @Override
-    public String[] getParameterValues(String name) {
+    public final String[] getParameterValues(String name) {
         String v = getParameter(name);
         if (v == null) {
             return new String[0];
@@ -242,8 +243,9 @@ public class MockRequest implements HttpServletRequest {
     }
 
     @Override
-    public Map getParameterMap() {
-        return parameters;
+    public final Map<String, String[]> getParameterMap() {
+        return Collections.unmodifiableMap(parameters.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> new String[] {e.getValue()})));
     }
 
     @Override
@@ -307,7 +309,7 @@ public class MockRequest implements HttpServletRequest {
     }
 
     @Override
-    public Enumeration getLocales() {
+    public Enumeration<Locale> getLocales() {
         // TODO
         throw new UnsupportedOperationException();
     }

--- a/core/src/test/java/org/kohsuke/stapler/RequestImplTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/RequestImplTest.java
@@ -37,7 +37,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.List;
 import net.sf.json.JSONObject;
 import org.apache.commons.fileupload2.core.FileItem;
@@ -121,11 +120,6 @@ public class RequestImplTest {
             }
 
             @Override
-            public Enumeration getParameterNames() {
-                return Collections.enumeration(List.of("p1"));
-            }
-
-            @Override
             public ServletInputStream getInputStream() throws IOException {
                 return new ServletInputStream() {
                     @Override
@@ -160,6 +154,7 @@ public class RequestImplTest {
                 };
             }
         };
+        mockRequest.parameters.put("p1", "somevalue");
 
         RequestImpl request = new RequestImpl(stapler, mockRequest, Collections.emptyList(), null);
 


### PR DESCRIPTION
Noticed in CloudBees CI a stack trace under certain conditions (Move/Copy/Promote) now reproduced in a test

```
java.lang.UnsupportedOperationException
	at java.base/java.util.Collections$UnmodifiableMap.putAll(Collections.java:1665)
	at org.kohsuke.stapler.RequestImpl.getParameterMap(RequestImpl.java:266)
	at org.kohsuke.stapler.RequestImplTest.test_multipart_formdata(RequestImplTest.java:177)
```

First of all, `getParameterMap` is documented to return an immutable map. This was true in `javax.servlet` days, so not obviously a `jakarta.servlet` regression, though of course a particular version of Jetty might have started to enforce immutability.

Secondly, the return type was wrong! The value type is supposed to be `String[]`, not `String`. We were using rawtypes and so did not notice.

Both mistakes seem to date to #53, but _also_ were in the `MockRequest` dating all the way to cfb02d4c4e9a5ae4a68445f19aa7f2253439f57a.
