### PR TITLE
[JENKINS-75224] Remove support for `?jsonp` parameter in JSON flavor

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/ResponseImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/ResponseImpl.java
@@ -300,8 +300,7 @@ public class ResponseImpl extends HttpServletResponseWrapper implements StaplerR
         setContentType(flavor.contentType);
         Writer w = getWriter();
 
-        if (flavor == Flavor.JSON
-                || flavor == Flavor.JSONP) { // for compatibility reasons, accept JSON for JSONP as well.
+        if (flavor == Flavor.JSONP) {
             pad = req.getParameter("jsonp");
             if (pad != null) {
                 w.write(pad + '(');


### PR DESCRIPTION
[JENKINS-75224](https://issues.jenkins.io/browse/JENKINS-75224)

### Testing done

`mvn clean install -Dtest='ApiTest,UpdateCenterTest,DefaultCrumbIssuerTest'` in core

Compared https://ci.jenkins.io/contextMenu?jsonp=callback (`?jsonp` supported) to http://localhost:8080/jenkins/contextMenu?jsonp=callback (`?jsonp` ignored, looks like JSON now).

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
