### PR TITLE
Fix NPE in `FileItem` compatibility layer

### DIFF
--- a/core/src/main/java/org/apache/commons/fileupload/FileItem.java
+++ b/core/src/main/java/org/apache/commons/fileupload/FileItem.java
@@ -26,6 +26,7 @@ import java.io.UncheckedIOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
+import java.util.Objects;
 import org.apache.commons.fileupload2.core.FileItemHeadersProvider;
 
 /**
@@ -331,6 +332,7 @@ public interface FileItem {
     }
 
     static FileItem fromFileUpload2FileItem(org.apache.commons.fileupload2.core.FileItem from) {
+        Objects.requireNonNull(from);
         return new FileItem() {
 
             @Override

--- a/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
@@ -1320,7 +1320,8 @@ public class RequestImpl extends HttpServletRequestWrapper implements StaplerReq
     @Deprecated
     @Override
     public org.apache.commons.fileupload.FileItem getFileItem(String name) throws ServletException, IOException {
-        return org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(getFileItem2(name));
+        FileItem fileItem = getFileItem2(name);
+        return fileItem != null ? org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(fileItem) : null;
     }
 
     private static final Logger LOGGER = Logger.getLogger(RequestImpl.class.getName());


### PR DESCRIPTION
Fixes the root cause behind https://github.com/jenkinsci/file-parameters-plugin/issues/199. While https://github.com/jenkinsci/file-parameters-plugin/pull/215 chased away this problem by migrating away from the compatibility layer, the compatibility layer might still be in use in other plugins.

### Testing done

CI build

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
