### PR TITLE
Escape values inside JS string

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/bind/Bound.java
+++ b/core/src/main/java/org/kohsuke/stapler/bind/Bound.java
@@ -144,8 +144,8 @@ public abstract class Bound implements HttpResponse {
         return "makeStaplerProxy('" + escapeQuotedString(url) + "','" + crumb + "',[" + methodNamesList + "])";
     }
 
-    private static String escapeQuotedString(String singleQuotedJsValue) {
-        return singleQuotedJsValue.replace("'", "\\'");
+    static String escapeQuotedString(String singleQuotedJsValue) {
+        return singleQuotedJsValue.replace("\\", "\\\\").replace("'", "\\'");
     }
 
     private static String camelize(String name) {

--- a/core/src/main/java/org/kohsuke/stapler/bind/Bound.java
+++ b/core/src/main/java/org/kohsuke/stapler/bind/Bound.java
@@ -137,9 +137,15 @@ public abstract class Bound implements HttpResponse {
      */
     public static String getProxyScript(String url, String[] methods) {
         final String crumb = WebApp.getCurrent().getCrumbIssuer().issueCrumb();
-        final String methodNamesList =
-                Arrays.stream(methods).sorted().map(it -> "'" + it + "'").collect(Collectors.joining(","));
-        return "makeStaplerProxy('" + url + "','" + crumb + "',[" + methodNamesList + "])";
+        final String methodNamesList = Arrays.stream(methods)
+                .sorted()
+                .map(it -> "'" + escapeQuotedString(it) + "'")
+                .collect(Collectors.joining(","));
+        return "makeStaplerProxy('" + escapeQuotedString(url) + "','" + crumb + "',[" + methodNamesList + "])";
+    }
+
+    private static String escapeQuotedString(String singleQuotedJsValue) {
+        return singleQuotedJsValue.replace("'", "\\'");
     }
 
     private static String camelize(String name) {

--- a/core/src/main/java/org/kohsuke/stapler/bind/Bound.java
+++ b/core/src/main/java/org/kohsuke/stapler/bind/Bound.java
@@ -144,7 +144,7 @@ public abstract class Bound implements HttpResponse {
         return "makeStaplerProxy('" + escapeQuotedString(url) + "','" + crumb + "',[" + methodNamesList + "])";
     }
 
-    static String escapeQuotedString(String singleQuotedJsValue) {
+    private static String escapeQuotedString(String singleQuotedJsValue) {
         return singleQuotedJsValue.replace("\\", "\\\\").replace("'", "\\'");
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <version>10.22.0</version>
+              <version>10.23.0</version>
             </dependency>
           </dependencies>
           <executions>


### PR DESCRIPTION
Someone reported to us that the URL portion was not properly escaped in URLs like the following, resulting in broken JS:

`http://localhost:8080/$stapler/bound/script/foo'bar'baz?var=proxy&methods=foo,bar`

Previously output was:
`proxy = makeStaplerProxy('/foo'bar'baz','a534b6b86f174fb6a2180a8cc9ad94589eabfc75149c2e1faec6fc2a5448a275',['bar','foo']);`

Now output is:
`proxy = makeStaplerProxy('/foo\'bar\'baz','a534b6b86f174fb6a2180a8cc9ad94589eabfc75149c2e1faec6fc2a5448a275',['bar','foo']);`

This is in the code branch for `WithWellKnownURL` which hasn't had an implementation in about a decade as far as I'm aware, and even before it wasn't in a relevant plugin. This fixes the case for when there's ever a `WithWellKnownURL` that has single quotes in its URL.

There is no security impact, so this is merely a minor bug fix.

Amends https://github.com/jenkinsci/stapler/pull/385.

### Testing done

Accessing the above URLs.

Core PR with test coverage: https://github.com/jenkinsci/jenkins/pull/10500

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
