### PR TITLE
More efficient `LargeText.doProgressText`

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/framework/io/LargeText.java
+++ b/core/src/main/java/org/kohsuke/stapler/framework/io/LargeText.java
@@ -317,7 +317,10 @@ public class LargeText {
             rsp.addHeader("X-More-Data", "true");
         }
 
-        try (var w = rsp.getWriter(); var lenw = new LineEndNormalizingWriter(w); var os = new WriterOutputStream(lenw, charset); var tos = new ThresholdingOutputStream(os, length - start)) {
+        try (var w = rsp.getWriter();
+                var lenw = new LineEndNormalizingWriter(w);
+                var os = new WriterOutputStream(lenw, charset);
+                var tos = new ThresholdingOutputStream(os, length - start)) {
             writeLogUncounted(start, os);
         }
     }

--- a/core/src/main/java/org/kohsuke/stapler/framework/io/LargeText.java
+++ b/core/src/main/java/org/kohsuke/stapler/framework/io/LargeText.java
@@ -237,8 +237,11 @@ public class LargeText {
         return os.getByteCount() + start;
     }
 
-    private void writeLogUncounted(long start, OutputStream os) throws IOException {
-
+    /**
+     * Implementation of {@link #writeLogTo} which does not track how much was written.
+     */
+    protected void writeLogUncounted(long start, OutputStream os) throws IOException {
+        System.err.println("TODO writeLogUncounted on " + os);
         try (Session f = source.open()) {
             f.skip(start);
 
@@ -321,6 +324,7 @@ public class LargeText {
                 var lenw = new LineEndNormalizingWriter(w);
                 var os = new WriterOutputStream(lenw, charset);
                 var tos = new ThresholdingOutputStream(os, length - start)) {
+            System.err.println("TODO doProgressTextImpl");
             writeLogUncounted(start, os);
         }
     }


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/10236#issuecomment-2784870058 alternative.

Requires https://github.com/jenkinsci/jenkins/pull/10515.

Testing notes in https://github.com/jenkinsci/workflow-job-plugin/pull/528.