### PR TITLE
Allow releasing bound objects via HTTP

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
@@ -216,6 +216,7 @@ public class RequestImpl extends HttpServletRequestWrapper implements StaplerReq
         return new RenderOnDemandParameters(
                 "makeStaplerProxy",
                 bound.getURL(),
+                bound.getReleaseURL(),
                 getWebApp().getCrumbIssuer().issueCrumb(),
                 bound.getBoundJavaScriptUrlNames());
     }

--- a/core/src/main/java/org/kohsuke/stapler/StaplerRequest.java
+++ b/core/src/main/java/org/kohsuke/stapler/StaplerRequest.java
@@ -571,12 +571,14 @@ public interface StaplerRequest extends HttpServletRequest {
     final class RenderOnDemandParameters {
         public final String proxyMethod;
         public final String url;
+        public final String releaseUrl;
         public final String crumb;
         public final Set<String> urlNames;
 
-        public RenderOnDemandParameters(String proxyMethod, String url, String crumb, Set<String> urlNames) {
+        public RenderOnDemandParameters(String proxyMethod, String url, String releaseUrl, String crumb, Set<String> urlNames) {
             this.proxyMethod = proxyMethod;
             this.url = url;
+            this.releaseUrl = releaseUrl;
             this.crumb = crumb;
             this.urlNames = urlNames;
         }
@@ -998,7 +1000,7 @@ public interface StaplerRequest extends HttpServletRequest {
         @Override
         public RenderOnDemandParameters createJavaScriptProxyParameters(Object toBeExported) {
             StaplerRequest.RenderOnDemandParameters result = from.createJavaScriptProxyParameters(toBeExported);
-            return new RenderOnDemandParameters(result.proxyMethod, result.url, result.crumb, result.urlNames);
+            return new RenderOnDemandParameters(result.proxyMethod, result.url, result.releaseUrl, result.crumb, result.urlNames);
         }
 
         @Override
@@ -1654,7 +1656,7 @@ public interface StaplerRequest extends HttpServletRequest {
         @Override
         public RenderOnDemandParameters createJavaScriptProxyParameters(Object toBeExported) {
             StaplerRequest2.RenderOnDemandParameters result = from.createJavaScriptProxyParameters(toBeExported);
-            return new RenderOnDemandParameters(result.proxyMethod, result.crumb, result.url, result.urlNames);
+            return new RenderOnDemandParameters(result.proxyMethod, result.crumb, result.url, result.releaseUrl, result.urlNames);
         }
 
         @Override

--- a/core/src/main/java/org/kohsuke/stapler/StaplerRequest2.java
+++ b/core/src/main/java/org/kohsuke/stapler/StaplerRequest2.java
@@ -533,12 +533,14 @@ public interface StaplerRequest2 extends HttpServletRequest {
     final class RenderOnDemandParameters {
         public final String proxyMethod;
         public final String url;
+        public final String releaseUrl;
         public final String crumb;
         public final Set<String> urlNames;
 
-        public RenderOnDemandParameters(String proxyMethod, String url, String crumb, Set<String> urlNames) {
+        public RenderOnDemandParameters(String proxyMethod, String url, String releaseUrl, String crumb, Set<String> urlNames) {
             this.proxyMethod = proxyMethod;
             this.url = url;
+            this.releaseUrl = releaseUrl;
             this.crumb = crumb;
             this.urlNames = urlNames;
         }

--- a/core/src/main/java/org/kohsuke/stapler/bind/Bound.java
+++ b/core/src/main/java/org/kohsuke/stapler/bind/Bound.java
@@ -55,6 +55,13 @@ public abstract class Bound implements HttpResponse {
     public abstract String getURL();
 
     /**
+     * The URL where the object can be released, or {@code null} if not applicable.
+     */
+    public String getReleaseURL() {
+        return null;
+    }
+
+    /**
      * Gets the bound object.
      */
     public abstract Object getTarget();

--- a/core/src/main/java/org/kohsuke/stapler/bind/BoundObjectTable.java
+++ b/core/src/main/java/org/kohsuke/stapler/bind/BoundObjectTable.java
@@ -76,6 +76,27 @@ public class BoundObjectTable implements StaplerFallback {
     }
 
     /**
+     * Explicitly unbind this object via HTTP.
+     *
+     * @throws HttpResponses.HttpResponseException expected outcome returning 200 OK
+     */
+    public void doRelease(StaplerRequest2 req, StaplerResponse2 rsp) throws HttpResponses.HttpResponseException, IOException {
+        final Table table = resolve(false);
+        if (table == null) {
+            rsp.sendError(404);
+        }
+
+        String id = req.getRestOfPath().replace("/", "");
+
+        Object object = table.resolve(id);
+        if (object == null) {
+            rsp.sendError(200);
+        }
+        table.release(id);
+        rsp.sendError(200);
+    }
+
+    /**
      * This serves the script content for a bound object. Support CSP-compatible st:bind and similar methods of making
      * objects accessible to JS.
      *
@@ -239,6 +260,11 @@ public class BoundObjectTable implements StaplerFallback {
                 }
 
                 @Override
+                public String getReleaseURL() {
+                    return Stapler.getCurrentRequest2().getContextPath() + RELEASE_PREFIX + id;
+                }
+
+                @Override
                 public String getURL() {
                     return Stapler.getCurrentRequest2().getContextPath() + PREFIX + id;
                 }
@@ -374,6 +400,7 @@ public class BoundObjectTable implements StaplerFallback {
     }
 
     public static final String PREFIX = "/$stapler/bound/";
+    public static final String RELEASE_PREFIX = "/$stapler/bound/release/";
     static final String SCRIPT_PREFIX = "/$stapler/bound/script";
 
     /**


### PR DESCRIPTION
Experimental alternative to https://github.com/jenkinsci/stapler/pull/663.

I expect time-based expiration to be problematic (https://github.com/jenkinsci/stapler/pull/663#discussion_r2078958053) so this instead allows releasing bound objects when navigating away from the page that registered the proxies.

Pros: Proxies continue to exist until you leave the page.
Cons: Browser involvement needed, a page can accumulate proxies in badly-written code. Probably more.

The current implementation sends one request per proxy, could be collapsed to just one if this approach is deemed preferable.

### Testing done

1. Script console from https://github.com/jenkinsci/jenkins/pull/10623#discussion_r2075789533: Empty
2. Navigate to a job config screen
3. Script console: Very much not empty
4. Navigate away via breadcrumbs
5. Script console: Empty again

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
