### PR TITLE
Bubble up exceptions from calling `@DataBoundSetter` methods

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
@@ -693,18 +693,8 @@ public class RequestImpl extends HttpServletRequestWrapper implements StaplerReq
             x.initCause(e);
             throw x;
         } catch (InvocationTargetException e) {
-            Throwable x = e.getTargetException();
-            if (x instanceof Error) {
-                throw (Error) x;
-            }
-            if (x instanceof RuntimeException) {
-                throw (RuntimeException) x;
-            }
-            // TODO apply similar logic to other catchers of InvocationTargetException as needed
-            if (x instanceof HttpResponse) {
-                throw HttpResponses.wrap((HttpResponse) x);
-            }
-            throw new IllegalArgumentException(x);
+            launderITE(e);
+            return null; // never reached, but keeps the compiler happy
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Failed to invoke " + c + " with " + Arrays.asList(args), e);
         }
@@ -1079,8 +1069,10 @@ public class RequestImpl extends HttpServletRequestWrapper implements StaplerReq
 
                     // only invoking public methods for security reasons
                     wm.invoke(r, bindJSON(wm.getGenericParameterTypes()[0], pt[0], j.get(key)));
-                } catch (IllegalAccessException | InvocationTargetException e) {
+                } catch (IllegalAccessException e) {
                     LOGGER.log(Level.WARNING, "Cannot access property " + key + " of " + r.getClass(), e);
+                } catch (InvocationTargetException e) {
+                    launderITE(e);
                 }
             }
         }
@@ -1088,6 +1080,24 @@ public class RequestImpl extends HttpServletRequestWrapper implements StaplerReq
         invokePostConstruct(getWebApp().getMetaClass(r).getPostConstructMethods(), r);
 
         return r;
+    }
+
+    /**
+     * Launders {@link InvocationTargetException} to throw the actual exception
+     */
+    private static void launderITE(InvocationTargetException e) {
+        Throwable x = e.getTargetException();
+        if (x instanceof Error err) {
+            throw err;
+        }
+        if (x instanceof RuntimeException rt) {
+            throw rt;
+        }
+        // TODO apply similar logic to other catchers of InvocationTargetException as needed
+        if (x instanceof HttpResponse httpResponse) {
+            throw HttpResponses.wrap(httpResponse);
+        }
+        throw new IllegalArgumentException(x);
     }
 
     private Method findDataBoundSetter(Class c, String name) {


### PR DESCRIPTION
Instead of just ignoring them and logging a warning, these should be bubbled up the same way as `@DataBoundConstructor` constructors.

<!-- Please describe your pull request here. -->

### Testing done

Implement a `setXXX` method annotated with @DataBoundSetter, throwing a `Descriptor.FormException`. Verified that the corresponding message gets displayed when saving using "Save" and "Apply" from a Jenkins form, instead of an incorrect configuration being applied silently.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
