### PR TITLE
Fix AbstractStaplerTest based tests

### DIFF
--- a/core/src/test/java/org/kohsuke/stapler/AbstractStaplerTestBase.java
+++ b/core/src/test/java/org/kohsuke/stapler/AbstractStaplerTestBase.java
@@ -44,4 +44,11 @@ public abstract class AbstractStaplerTestBase extends TestCase {
         this.response = new ResponseImpl(stapler, rawResponse);
         Stapler.CURRENT_RESPONSE.set(this.response);
     }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        Stapler.CURRENT_REQUEST.remove();
+        Stapler.CURRENT_RESPONSE.remove();
+    }
 }

--- a/core/src/test/java/org/kohsuke/stapler/ResponseImplTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/ResponseImplTest.java
@@ -12,49 +12,47 @@ import org.kohsuke.stapler.test.AbstractStaplerTest;
 /**
  * @author Kohsuke Kawaguchi
  */
-public class ResponseImplTest {
-    public static class RedirectTest extends AbstractStaplerTest {
-        @Override
-        protected void setUp() throws Exception {
-            super.setUp();
-            when(rawRequest.getScheme()).thenReturn("http");
-            when(rawRequest.getServerName()).thenReturn("example.com");
-            when(rawRequest.getServerPort()).thenReturn(80);
-            when(rawRequest.getRequestURI()).thenReturn("/foo/bar/zot");
-            when(rawResponse.getOutputStream()).thenReturn(new ServletOutputStream() {
-                @Override
-                public void write(int b) throws IOException {
-                    throw new AssertionError();
-                }
+public class ResponseImplTest extends AbstractStaplerTest {
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        when(rawRequest.getScheme()).thenReturn("http");
+        when(rawRequest.getServerName()).thenReturn("example.com");
+        when(rawRequest.getServerPort()).thenReturn(80);
+        when(rawRequest.getRequestURI()).thenReturn("/foo/bar/zot");
+        when(rawResponse.getOutputStream()).thenReturn(new ServletOutputStream() {
+            @Override
+            public void write(int b) throws IOException {
+                throw new AssertionError();
+            }
 
-                @Override
-                public boolean isReady() {
-                    return false;
-                }
+            @Override
+            public boolean isReady() {
+                return false;
+            }
 
-                @Override
-                public void setWriteListener(WriteListener writeListener) {
-                    // ignores
-                }
-            });
-        }
+            @Override
+            public void setWriteListener(WriteListener writeListener) {
+                // ignores
+            }
+        });
+    }
 
-        public void testSendRedirectRelative() throws IOException {
-            response.sendRedirect(HttpServletResponse.SC_SEE_OTHER, "foobar");
-            verify(rawResponse).setStatus(HttpServletResponse.SC_SEE_OTHER);
-            verify(rawResponse).setHeader("Location", "http://example.com/foo/bar/foobar");
-        }
+    public void testSendRedirectRelative() throws IOException {
+        response.sendRedirect(HttpServletResponse.SC_SEE_OTHER, "foobar");
+        verify(rawResponse).setStatus(HttpServletResponse.SC_SEE_OTHER);
+        verify(rawResponse).setHeader("Location", "http://example.com/foo/bar/foobar");
+    }
 
-        public void testSendRedirectWithinHost() throws IOException {
-            response.sendRedirect(HttpServletResponse.SC_SEE_OTHER, "/foobar");
-            verify(rawResponse).setStatus(HttpServletResponse.SC_SEE_OTHER);
-            verify(rawResponse).setHeader("Location", "http://example.com/foobar");
-        }
+    public void testSendRedirectWithinHost() throws IOException {
+        response.sendRedirect(HttpServletResponse.SC_SEE_OTHER, "/foobar");
+        verify(rawResponse).setStatus(HttpServletResponse.SC_SEE_OTHER);
+        verify(rawResponse).setHeader("Location", "http://example.com/foobar");
+    }
 
-        public void testSendRedirectAbsoluteURL() throws IOException {
-            response.sendRedirect(HttpServletResponse.SC_SEE_OTHER, "https://jenkins-ci.org/");
-            verify(rawResponse).setStatus(HttpServletResponse.SC_SEE_OTHER);
-            verify(rawResponse).setHeader("Location", "https://jenkins-ci.org/");
-        }
+    public void testSendRedirectAbsoluteURL() throws IOException {
+        response.sendRedirect(HttpServletResponse.SC_SEE_OTHER, "https://jenkins-ci.org/");
+        verify(rawResponse).setStatus(HttpServletResponse.SC_SEE_OTHER);
+        verify(rawResponse).setHeader("Location", "https://jenkins-ci.org/");
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

While working on the tests for https://github.com/jenkinsci/stapler/pull/703, I noticed that the `RedirectTest` cases inside `ResponseImplTest` are not being run. It looks like nested classes are not invoked.

After fixing this, an unrelated test started failing:
https://github.com/jenkinsci/stapler/blob/87c77d1dbc9e471e85454c6925a5aee3312378f6/core/src/test/java/org/kohsuke/stapler/StaplerTest.java#L95-L96

It turned out that the `AbstractStaplerTest` class was missing a teardown of global state.

### Testing done

These are test-only changes.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
