### PR TITLE
Add new streaming mode for LargeText

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/framework/io/LargeText.java
+++ b/core/src/main/java/org/kohsuke/stapler/framework/io/LargeText.java
@@ -41,8 +41,10 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.zip.GZIPInputStream;
+import net.sf.json.JSONObject;
 import org.apache.commons.io.output.CountingOutputStream;
 import org.kohsuke.stapler.ReflectionUtils;
+import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse;
@@ -89,6 +91,8 @@ public class LargeText {
     protected final Charset charset;
 
     private volatile boolean completed;
+
+    private JSONObject streamingMeta;
 
     public LargeText(File file, boolean completed) {
         this(file, Charset.defaultCharset(), completed);
@@ -257,13 +261,24 @@ public class LargeText {
     }
 
     private void writeLogUncounted(long start, OutputStream os) throws IOException {
-
         try (Session f = source.open()) {
             if (f.skip(start) != start) {
                 throw new EOFException("Attempted to read past the end of the log");
             }
 
-            if (completed) {
+            if (isStreamingRequest(Stapler.getCurrentRequest2())) {
+                // write everything until the previously determined EOF in bulk
+                long end = source.length();
+                long pos = start;
+                byte[] buf = new byte[64 * 1024];
+                int n;
+                while (pos < end && (n = f.read(buf)) >= 0) {
+                    long remaining = end - pos;
+                    if (n > remaining) n = (int) remaining;
+                    os.write(buf, 0, n);
+                    pos += n;
+                }
+            } else if (completed) {
                 // write everything till EOF
                 byte[] buf = new byte[1024];
                 int sz;
@@ -310,7 +325,93 @@ public class LargeText {
         doProgressTextImpl(StaplerRequest.toStaplerRequest2(req), StaplerResponse.toStaplerResponse2(rsp));
     }
 
+    /**
+     * Detect use of streaming mode.
+     * @param req The current request.
+     * @return true if the new streaming mode is requested.
+     */
+    public boolean isStreamingRequest(StaplerRequest2 req) {
+        if (req == null) return false;
+        return "true".equals(req.getHeader("X-Streaming"));
+    }
+
+    /**
+     * Add additional meta data to a streaming response.
+     * @param key The field to (over)write meta data for.
+     * @param value The meta data value.
+     */
+    protected void putStreamingMeta(String key, Object value) {
+        if (streamingMeta == null) streamingMeta = new JSONObject();
+        streamingMeta.put(key, value);
+    }
+
+    private long findNextLineStart(long start, long stop) throws IOException {
+        try (var f = source.open()) {
+            if (f.skip(start) != start) {
+                // The log file rolled over, send it in full.
+                return 0;
+            }
+            byte[] buf = new byte[64 * 1024];
+            long searchPosition = start;
+            int n;
+            while (searchPosition + 1 < stop && (n = f.read(buf)) > 0) {
+                for (int i = 0; i < n && searchPosition + 1 < stop; i++) {
+                    if (buf[i] == '\n') {
+                        // We have a match, send from after the \n.
+                        putStreamingMeta("startFromNewLine", true);
+                        return searchPosition + 1;
+                    }
+                    searchPosition++;
+                }
+            }
+        }
+        // fall back to original start.
+        return start;
+    }
+
+    private void doProgressTextStreaming(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
+        setContentType(rsp);
+        rsp.setHeader("X-Streaming", "true");
+        rsp.setStatus(HttpServletResponse.SC_OK);
+        putStreamingMeta("completed", completed);
+
+        try (var w = rsp.getWriter()) {
+            long length = source.exists() ? source.length() : 0;
+
+            String s = req.getParameter("start");
+            long start = (s != null) ? Long.parseLong(s) : 0;
+            if (start > length) {
+                // text rolled over, send in full
+                start = 0;
+            } else if (start < 0 && length <= -start) {
+                // tail on small file, send in full
+                start = 0;
+            } else if (start < 0) {
+                // tail on large file, start at first new line in tail
+                start = findNextLineStart(length + start, length);
+            } else if (req.getParameter("searchNewLineUntil") != null) {
+                // fetch more, start at first new line before last start
+                long searchStop = Long.parseLong(req.getParameter("searchNewLineUntil"));
+                start = findNextLineStart(start, searchStop);
+            }
+            putStreamingMeta("start", start);
+
+            long end = length;
+            if (start != end) {
+                end = writeLogTo(start, w);
+            }
+            putStreamingMeta("end", end);
+
+            w.write("\n" + streamingMeta);
+        }
+    }
+
     private void doProgressTextImpl(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
+        if (isStreamingRequest(req)) {
+            doProgressTextStreaming(req, rsp);
+            return;
+        }
+
         setContentType(rsp);
         rsp.setStatus(HttpServletResponse.SC_OK);
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- Part of https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/704

This PR adds a new streaming mode for `LargeText` that allows unbuffered reads (on the stapler layer).

There are two implementations in this PR: a "simple" mixed content type response (`<log>\n<metadata>`); and a proper RFC compliant `multipart/form-data` response body behind standard content negotiation via `Accepts`.

Support for `multipart/form-data` is good in the browser (part of the `fetch` spec), but rather poor in Java/Jenkins test framework. With that said and after a few iterations on the implementation, I'm quite happy with the multipart approach and actually prefer it over the other mode.

Example:
```
GET /job/foo/210/execution/node/36/log/logText/progressiveHtml?start=42
Accept: multipart/form-data
```
```
Content-Type: multipart/form-data;boundary=<uuid>
--<uuid>
Content-Disposition: form-data;name=text
Content-Type: text/html;charset=UTF-8

<log text from position 42>
--<uuid>
Content-Disposition: form-data;name=meta
Content-Type: application/json;charset=utf-8

{"completed":true,"start":42,"consoleAnnotator":"<...>","end":1337}
--<uuid>--
```

<details>
<summary> full curl </summary>

Build: Stapler -> Jenkins -> Workflow-api -> pipeline-graph-view-plugin

```
$ curl -i -H 'Accept: multipart/form-data' 'http://localhost:8080/jenkins/job/issues/job/one%20step%20and%20large%20output/48/execution/node/13/log/logText/progressiveHtml?start=15040'
HTTP/1.1 200 OK
Server: Jetty(12.0.22)
Date: Tue, 07 Oct 2025 21:56:40 GMT
X-Content-Type-Options: nosniff
Stapler-Trace-001: -> evaluate(<hudson.model.Hudson@7716f588> :hudson.model.Hudson,"/job/issues/job/one%20step%20and%20large%20output/48/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-002: -> evaluate(((StaplerProxy)<hudson.model.Hudson@7716f588>).getTarget(),"/job/issues/job/one%20step%20and%20large%20output/48/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-003: -> evaluate(<hudson.model.Hudson@7716f588>.getJob("issues"),"/job/one%20step%20and%20large%20output/48/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-004: -> evaluate(<com.cloudbees.hudson.plugins.folder.Folder@5d8ce06f[issues]> :com.cloudbees.hudson.plugins.folder.Folder,"/job/one%20step%20and%20large%20output/48/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-005: -> evaluate(((StaplerProxy)<com.cloudbees.hudson.plugins.folder.Folder@5d8ce06f[issues]>).getTarget(),"/job/one%20step%20and%20large%20output/48/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-006: -> evaluate(<com.cloudbees.hudson.plugins.folder.Folder@5d8ce06f[issues]>.getJob("one step and large output"),"/48/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-007: -> evaluate(<org.jenkinsci.plugins.workflow.job.WorkflowJob@1eee4b09[issues/one step and large output]> :org.jenkinsci.plugins.workflow.job.WorkflowJob,"/48/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-008: -> evaluate(((StaplerProxy)<org.jenkinsci.plugins.workflow.job.WorkflowJob@1eee4b09[issues/one step and large output]>).getTarget(),"/48/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-009: -> evaluate(<org.jenkinsci.plugins.workflow.job.WorkflowJob@1eee4b09[issues/one step and large output]>.getDynamic("48",...),"/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-010: -> evaluate(<issues/one step and large output #48> :org.jenkinsci.plugins.workflow.job.WorkflowRun,"/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-011: -> evaluate(((StaplerProxy)<issues/one step and large output #48>).getTarget(),"/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-012: -> evaluate(<issues/one step and large output #48>.getExecution(),"/node/13/log/logText/progressiveHtml")
Stapler-Trace-013: -> evaluate(<CpsFlowExecution[issues/one step and large output#48]> :org.jenkinsci.plugins.workflow.cps.CpsFlowExecution,"/node/13/log/logText/progressiveHtml")
Stapler-Trace-014: -> evaluate(<CpsFlowExecution[issues/one step and large output#48]>.getNode("13"),"/log/logText/progressiveHtml")
Stapler-Trace-015: -> evaluate(<StepAtomNode[id=13, exec=CpsFlowExecution[issues/one step and large output#48]]> :org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode,"/log/logText/progressiveHtml")
Stapler-Trace-016: -> evaluate(<StepAtomNode[id=13, exec=CpsFlowExecution[issues/one step and large output#48]]>.getDynamic("log",...),"/logText/progressiveHtml")
Stapler-Trace-017: -> evaluate(<org.jenkinsci.plugins.workflow.support.actions.LogStorageAction@2aa8ca8d> :org.jenkinsci.plugins.workflow.support.actions.LogStorageAction,"/logText/progressiveHtml")
Stapler-Trace-018: -> evaluate(<org.jenkinsci.plugins.workflow.support.actions.LogStorageAction@2aa8ca8d>.getLogText(),"/progressiveHtml")
Stapler-Trace-019: -> evaluate(<hudson.console.AnnotatedLargeText@65bd38ed> :hudson.console.AnnotatedLargeText,"/progressiveHtml")
Stapler-Trace-020: -> <hudson.console.AnnotatedLargeText@65bd38ed>.doProgressiveHtml(...)
Content-Type: multipart/form-data;boundary=ea7fbd0c-8bae-4fc4-9e0f-2af7965618e3;charset=utf-8
Transfer-Encoding: chunked

--ea7fbd0c-8bae-4fc4-9e0f-2af7965618e3
Content-Disposition: form-data;name=text
Content-Type: text/html;charset=utf-8

<span class="timestamp"><b>23:56:00</b> </span><span style="display: none">[2025-10-07T21:56:00.505Z]</span> + echo Slept 116 times
<span class="timestamp"><b>23:56:00</b> </span><span style="display: none">[2025-10-07T21:56:00.505Z]</span> Slept 116 times
<span class="timestamp"><b>23:56:00</b> </span><span style="display: none">[2025-10-07T21:56:00.505Z]</span> + sleep 0.2
<span class="timestamp"><b>23:56:00</b> </span><span style="display: none">[2025-10-07T21:56:00.755Z]</span> + echo Slept 117 times
<span class="timestamp"><b>23:56:00</b> </span><span style="display: none">[2025-10-07T21:56:00.755Z]</span> Slept 117 times
<span class="timestamp"><b>23:56:00</b> </span><span style="display: none">[2025-10-07T21:56:00.755Z]</span> + sleep 0.2
<span class="timestamp"><b>23:56:01</b> </span><span style="display: none">[2025-10-07T21:56:01.006Z]</span> + echo Slept 118 times
<span class="timestamp"><b>23:56:01</b> </span><span style="display: none">[2025-10-07T21:56:01.006Z]</span> Slept 118 times
<span class="timestamp"><b>23:56:01</b> </span><span style="display: none">[2025-10-07T21:56:01.006Z]</span> + sleep 0.2
<span class="timestamp"><b>23:56:01</b> </span><span style="display: none">[2025-10-07T21:56:01.006Z]</span> + echo Slept 119 times
<span class="timestamp"><b>23:56:01</b> </span><span style="display: none">[2025-10-07T21:56:01.006Z]</span> Slept 119 times
<span class="timestamp"><b>23:56:01</b> </span><span style="display: none">[2025-10-07T21:56:01.006Z]</span> + sleep 0.2
<span class="timestamp"><b>23:56:01</b> </span><span style="display: none">[2025-10-07T21:56:01.257Z]</span> + echo Slept 120 times
<span class="timestamp"><b>23:56:01</b> </span><span style="display: none">[2025-10-07T21:56:01.257Z]</span> Slept 120 times

--ea7fbd0c-8bae-4fc4-9e0f-2af7965618e3
Content-Disposition: form-data;name=meta
Content-Type: application/json;charset=utf-8

{"completed":true,"start":15040,"consoleAnnotator":"29WvJ6Nq5NEMeDyXEB5HvKPF+yUI8E1iE0pxj1zEnWQge/Qhtvl07DSrrRkXBg7CYFBkhn7Vdlrxgdn02RUBUvo1P4+mDdtgVm2KvYnG4jlxQPBnGhk/ml2/2zAlTw4eHQVwpd+oJlOnoilotnczf4AtApdjir0Y4Q3qSsZC4aT8Zh8kKSWSXpZIp0Te2+dnew+xBqiClRUdI91+/STvI3CGuKS01uhowwVEvA3PB7excDxQge/mcHZNa6ea9SMkKBVQBSxpRU2+1GPhJy9IUzjQzjJ1AnBIky+I26k7wCvlaUc5o+nTW9UsEXKcADHy","end":15661}
--ea7fbd0c-8bae-4fc4-9e0f-2af7965618e3--
```

Tail
```
 curl -i -H 'Accept: multipart/form-data' 'http://localhost:8080/jenkins/job/issues/job/one%20step%20and%20large%20output/48/execution/node/13/log/logText/progressiveHtml?start=-200'
HTTP/1.1 200 OK
Server: Jetty(12.0.22)
Date: Tue, 07 Oct 2025 22:01:38 GMT
X-Content-Type-Options: nosniff
Stapler-Trace-001: -> evaluate(<hudson.model.Hudson@7716f588> :hudson.model.Hudson,"/job/issues/job/one%20step%20and%20large%20output/48/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-002: -> evaluate(((StaplerProxy)<hudson.model.Hudson@7716f588>).getTarget(),"/job/issues/job/one%20step%20and%20large%20output/48/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-003: -> evaluate(<hudson.model.Hudson@7716f588>.getJob("issues"),"/job/one%20step%20and%20large%20output/48/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-004: -> evaluate(<com.cloudbees.hudson.plugins.folder.Folder@5d8ce06f[issues]> :com.cloudbees.hudson.plugins.folder.Folder,"/job/one%20step%20and%20large%20output/48/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-005: -> evaluate(((StaplerProxy)<com.cloudbees.hudson.plugins.folder.Folder@5d8ce06f[issues]>).getTarget(),"/job/one%20step%20and%20large%20output/48/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-006: -> evaluate(<com.cloudbees.hudson.plugins.folder.Folder@5d8ce06f[issues]>.getJob("one step and large output"),"/48/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-007: -> evaluate(<org.jenkinsci.plugins.workflow.job.WorkflowJob@1eee4b09[issues/one step and large output]> :org.jenkinsci.plugins.workflow.job.WorkflowJob,"/48/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-008: -> evaluate(((StaplerProxy)<org.jenkinsci.plugins.workflow.job.WorkflowJob@1eee4b09[issues/one step and large output]>).getTarget(),"/48/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-009: -> evaluate(<org.jenkinsci.plugins.workflow.job.WorkflowJob@1eee4b09[issues/one step and large output]>.getDynamic("48",...),"/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-010: -> evaluate(<issues/one step and large output #48> :org.jenkinsci.plugins.workflow.job.WorkflowRun,"/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-011: -> evaluate(((StaplerProxy)<issues/one step and large output #48>).getTarget(),"/execution/node/13/log/logText/progressiveHtml")
Stapler-Trace-012: -> evaluate(<issues/one step and large output #48>.getExecution(),"/node/13/log/logText/progressiveHtml")
Stapler-Trace-013: -> evaluate(<CpsFlowExecution[issues/one step and large output#48]> :org.jenkinsci.plugins.workflow.cps.CpsFlowExecution,"/node/13/log/logText/progressiveHtml")
Stapler-Trace-014: -> evaluate(<CpsFlowExecution[issues/one step and large output#48]>.getNode("13"),"/log/logText/progressiveHtml")
Stapler-Trace-015: -> evaluate(<StepAtomNode[id=13, exec=CpsFlowExecution[issues/one step and large output#48]]> :org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode,"/log/logText/progressiveHtml")
Stapler-Trace-016: -> evaluate(<StepAtomNode[id=13, exec=CpsFlowExecution[issues/one step and large output#48]]>.getDynamic("log",...),"/logText/progressiveHtml")
Stapler-Trace-017: -> evaluate(<org.jenkinsci.plugins.workflow.support.actions.LogStorageAction@2aa8ca8d> :org.jenkinsci.plugins.workflow.support.actions.LogStorageAction,"/logText/progressiveHtml")
Stapler-Trace-018: -> evaluate(<org.jenkinsci.plugins.workflow.support.actions.LogStorageAction@2aa8ca8d>.getLogText(),"/progressiveHtml")
Stapler-Trace-019: -> evaluate(<hudson.console.AnnotatedLargeText@6e889c8f> :hudson.console.AnnotatedLargeText,"/progressiveHtml")
Stapler-Trace-020: -> <hudson.console.AnnotatedLargeText@6e889c8f>.doProgressiveHtml(...)
Content-Type: multipart/form-data;boundary=6991e90e-73e1-44c5-9595-45349de16ee6;charset=utf-8
Transfer-Encoding: chunked

--6991e90e-73e1-44c5-9595-45349de16ee6
Content-Disposition: form-data;name=text
Content-Type: text/html;charset=utf-8

<span class="timestamp"><b>23:56:01</b> </span><span style="display: none">[2025-10-07T21:56:01.006Z]</span> Slept 119 times
<span class="timestamp"><b>23:56:01</b> </span><span style="display: none">[2025-10-07T21:56:01.006Z]</span> + sleep 0.2
<span class="timestamp"><b>23:56:01</b> </span><span style="display: none">[2025-10-07T21:56:01.257Z]</span> + echo Slept 120 times
<span class="timestamp"><b>23:56:01</b> </span><span style="display: none">[2025-10-07T21:56:01.257Z]</span> Slept 120 times

--6991e90e-73e1-44c5-9595-45349de16ee6
Content-Disposition: form-data;name=meta
Content-Type: application/json;charset=utf-8

{"completed":true,"startFromNewLine":true,"start":15486,"consoleAnnotator":"29WvJ6Nq5NEMeDyXEB5HvH8SHvGOyYZDR/nOLpGd10TCByYndbhHBYGFMIxlMyqHCGtk2Yw2kJ/EulH83QM9o4RuZzyJrKyzJepx4a8Fg8gmjE5W9mMcmrmo7DxdepH4F0p3EhJHiWlKyze+knPQLY6ZHfmEtVEc+NkDJ3O/a0s4L0Qk5i/H1U89CeVYULscoDofrFBuAEGKBvM/lW2PDBd2oHiPan0QHgzNdCuQcBavrhkh4F//UtfezJq+U963gKlXOJfG+0cn37qxhlb0TL8UK37YEVCNdXvcAiHNCk+OYIl+Qk5wnKjs9zbO0HdR","end":15661}
--6991e90e-73e1-44c5-9595-45349de16ee6--
```

```
pipeline {
    agent any
    options { timestamps() }

    stages {
        stage('Hello') {
            steps {
                script {
                    for(int i=1; i<=1; i++) {
                        stage("Stage - ${i}") {
                            sh 'for i in `seq 120`; do sleep 0.2; echo "Slept ${i} times"; done'
                        }
                    }
                }
            }
        }
    }
}
```

</details>

I'll copy the implementation notes for each commit here:

- Simple implementation:
  - Clients request this new streaming mode via the request header
    `X-Streaming: true`.
    The server echoes it back to signal support for it.
  - A final new line is added to the body with a JSON payload that
    includes the start/end/completed state plus additional metadata from
    child classes. E.g. AnnotatedLargeText in Jenkins core will add the
    ConsoleAnnotator state when incrementally reading annotations.

    We are effectively creating a multi-part response with the first part
    being the plain-text/html console log followed by the second part with
    the metadata.
  - Bonus: Drop the line end normalization that was required for internet
    explorer. IE is long dead.
  - Bonus: Read the log in larger chunks of 64KiB and skip the buffering
    of each line.
    1kiB disk reads are far too small for today's disks, from NVMe disks
    to spinning rust; with all the other buffering removed, going to 1MiB
    would probably be fine too.
    The default stream buffer size in Node.js is 64KiB: https://nodejs.org/docs/latest-v22.x/api/stream.html#streamgetdefaulthighwatermarkobjectmode
  - Bonus: Add support for tailing via a negative `?start` query parameter
    in LargeText. It will try to find the next new line boundary to start
    reading from and fallback to the fixed tail if missing. The JSON blob
    will contain "startFromNewLine":true when starting from a new line.
    The same heuristic is available when fetching more bytes via
    `?searchNewLineUntil=<last start>`.

- `multipart/form-data` implementation
  - Clients request this new streaming mode via the standard request
    header 'Accept: multipart/form-data'. The server responds with a
    standard multipart response, i.e.
    'Content-Type: multipart/form-data;boundary=<uuid>'.
  - The browser fetch api has support for reading form-data multipart
    responses using 'response.formData()'.
  - The multipart response contains two parts:
    - "name=text", the original LargeText content and encoding as provided
      by the source (default UTF-8) via 'setContentType()'.
    - "name=meta", the json payload with streaming metadata as described
      in the previous commit.

### Testing done

See extensive test suite. Adopt it in progressive text in Jenkins. Adopt it in the pipeline-graph-view-plugin.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
