### PR TITLE
Use Jelly 1.1-jenkins-20260418

### DIFF
--- a/jelly/pom.xml
+++ b/jelly/pom.xml
@@ -12,7 +12,7 @@
   <description>Jelly binding for Stapler</description>
 
   <properties>
-    <jelly.version>1.1-jenkins-20250731</jelly.version>
+    <jelly.version>1.1-jenkins-20260418</jelly.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Use Jelly 1.1-jenkins-20260418

Includes jaxen 2.0.1 as described in their changelog:

* https://github.com/jaxen-xpath/jaxen/releases/tag/v2.0.1

Jaxen 2.0.1 is proposed for Jenkins core by pull request:

* https://github.com/jenkinsci/jenkins/pull/26666

### Testing done

* Tested with plugin BOM in:
  * https://github.com/jenkinsci/bom/pull/6680
* Tested with acceptance test harness in:
  * https://github.com/jenkinsci/acceptance-test-harness/pull/2684
* Automated tests all pass on my computer

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
