### PR TITLE
Rely on jenkinsci organization release drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,1 +1,1 @@
-_extends: jenkinsci/.github
+_extends: github:jenkinsci/.github:/.github/release-drafter.yml


### PR DESCRIPTION
## Rely on jenkinsci organization release drafter configuration

Automated release is failing because release drafter v7 dropped support for `_extends: .github` in the configuration.  It either needs to be removed or replaced with a more complete specification like:

`_extends: github:jenkinsci/.github:/.github/release-drafter.yml`

Adapts to release drafter changes in pull request:

* https://github.com/release-drafter/release-drafter/pull/1475

### Testing done

* None.  works in many repositories

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
