### PR TITLE
Avoid NPE in `getFileItem2` when request is not multipart

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
@@ -1340,6 +1340,9 @@ public class RequestImpl extends HttpServletRequestWrapper implements StaplerReq
 
     @Override
     public FileItem getFileItem2(String name) throws ServletException, IOException {
+        if (!isMultipart()) {
+            return null;
+        }
         parseMultipartFormData();
         if (parsedFormData == null) {
             return null;

--- a/core/src/test/java/org/kohsuke/stapler/RequestImplTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/RequestImplTest.java
@@ -27,6 +27,7 @@ package org.kohsuke.stapler;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.servlet.ReadListener;
@@ -179,6 +180,77 @@ class RequestImplTest {
 
         // Check getParameterMap
         assertTrue(request.getParameterMap().containsKey("text1"));
+    }
+
+    @Test
+    void test_npe_in_getFileItem2_without_content_type() throws IOException, ServletException {
+        final Stapler stapler = new Stapler();
+        final byte[] buf = generateMultipartData();
+        final ByteArrayInputStream is = new ByteArrayInputStream(buf);
+        final MockRequest mockRequest = new MockRequest() {
+            @Override
+            public String getContentType() {
+                return null; // Would usually be "multipart/form-data; boundary=mpboundary";
+            }
+
+            @Override
+            public String getCharacterEncoding() {
+                return "UTF-8";
+            }
+
+            @Override
+            public String getHeader(String name) {
+                // FILEUPLOAD-195/FILEUPLOAD-228: ignore FileUploadBase.CONTENT_LENGTH
+                return null;
+            }
+
+            @Override
+            public int getContentLength() {
+                return buf.length;
+            }
+
+            @Override
+            public ServletInputStream getInputStream() throws IOException {
+                return new ServletInputStream() {
+                    @Override
+                    public int read() throws IOException {
+                        return is.read();
+                    }
+
+                    @Override
+                    public int read(byte[] b) throws IOException {
+                        return is.read(b);
+                    }
+
+                    @Override
+                    public int read(byte[] b, int off, int len) throws IOException {
+                        return is.read(b, off, len);
+                    }
+
+                    @Override
+                    public boolean isFinished() {
+                        return is.available() != 0;
+                    }
+
+                    @Override
+                    public boolean isReady() {
+                        return true;
+                    }
+
+                    @Override
+                    public void setReadListener(ReadListener readListener) {
+                        // ignored
+                    }
+                };
+            }
+        };
+        mockRequest.parameters.put("p1", "somevalue");
+
+        RequestImpl request = new RequestImpl(stapler, mockRequest, Collections.emptyList(), null);
+
+        // Throws null pointer exception without the fix in
+        // https://github.com/jenkinsci/stapler/pull/769
+        assertNull(request.getFileItem2("pomFile"));
     }
 
     private byte[] generateMultipartData() throws IOException {


### PR DESCRIPTION
`RequestImpl.getFileItem2` calls `parseMultipartFormData()` unconditionally. With no `Content-Type` on the request, Commons FileUpload 2.x throws an internal NPE rather than `FileUploadContentTypeException`, so it escapes the catch chain.

Other call sites (`getParameter`, `getParameterMap`, ...) already guard with `isMultipart()`; just lining up `getFileItem2` with them.

Sibling of #651 from the FileUpload 1.x → 2.x migration. Surfaced downstream via [jenkinsci/file-parameters-plugin#199](https://github.com/jenkinsci/file-parameters-plugin/issues/199) on POST `/job/.../buildWithParameters` from a .NET client that doesn't send `Content-Type`