### PR TITLE
Fix Function class-init deadlock under concurrent class loading

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/Function.java
+++ b/core/src/main/java/org/kohsuke/stapler/Function.java
@@ -202,8 +202,8 @@ public abstract class Function {
                 }
 
                 // if the databinding method is provided, call that
-                Function binder = PARSE_METHODS.get(t);
-                if (binder != RETURN_NULL) {
+                Function binder = ParseMethodsHolder.PARSE_METHODS.get(t);
+                if (binder != ParseMethodsHolder.RETURN_NULL) {
                     arguments[i] = binder.bindAndInvoke(null, req, rsp);
                     continue;
                 }
@@ -218,62 +218,67 @@ public abstract class Function {
         return invoke(req, rsp, o, arguments);
     }
 
-    /**
-     * Computing map that discovers the static 'fromStapler' method from a class.
-     * The discovered method will be returned as a Function so that the invocation can do parameter injections.
-     */
-    private static final ClassValue<Function> PARSE_METHODS;
+    // Lazy-holder idiom: keeps Function.<clinit> free of inner-class construction,
+    // avoiding a class-init cycle with Function$MethodFunction under concurrent class loading.
+    private static final class ParseMethodsHolder {
+        private static final Function RETURN_NULL;
 
-    private static final Function RETURN_NULL;
+        /**
+         * Computing map that discovers the static 'fromStapler' method from a class.
+         * The discovered method will be returned as a Function so that the invocation can do parameter injections.
+         */
+        private static final ClassValue<Function> PARSE_METHODS;
 
-    static {
-        try {
-            RETURN_NULL = new StaticFunction(Function.class.getMethod("returnNull"));
-        } catch (NoSuchMethodException e) {
-            throw new AssertionError(e); // impossible
-        }
-
-        PARSE_METHODS = new ClassValue<>() {
-            @Override
-            public Function computeValue(Class<?> from) {
-                // MethdFunction for invoking a static method as a static method
-                FunctionList methods = new ClassDescriptor(from).methods.name("fromStapler");
-                switch (methods.size()) {
-                    case 0:
-                        return RETURN_NULL;
-                    case 1:
-                        Method m = ((MethodFunction) methods.get(0)).m;
-                        return new MethodFunction(m) {
-                            @Override
-                            public Class[] getParameterTypes() {
-                                return m.getParameterTypes();
-                            }
-
-                            @Override
-                            public Type[] getGenericParameterTypes() {
-                                return m.getGenericParameterTypes();
-                            }
-
-                            @Override
-                            public Annotation[][] getParameterAnnotations() {
-                                return m.getParameterAnnotations();
-                            }
-
-                            @Override
-                            public Object invoke(StaplerRequest2 req, StaplerResponse2 rsp, Object o, Object... args)
-                                    throws IllegalAccessException, InvocationTargetException {
-                                return m.invoke(null, args);
-                            }
-                        };
-                    default:
-                        throw new IllegalArgumentException("Too many 'fromStapler' methods on " + from);
-                }
+        static {
+            try {
+                RETURN_NULL = new StaticFunction(Function.class.getMethod("returnNull"));
+            } catch (NoSuchMethodException e) {
+                throw new AssertionError(e); // impossible
             }
-        };
+
+            PARSE_METHODS = new ClassValue<>() {
+                @Override
+                public Function computeValue(Class<?> from) {
+                    // MethodFunction for invoking a static method as a static method
+                    FunctionList methods = new ClassDescriptor(from).methods.name("fromStapler");
+                    switch (methods.size()) {
+                        case 0:
+                            return RETURN_NULL;
+                        case 1:
+                            Method m = ((MethodFunction) methods.get(0)).m;
+                            return new MethodFunction(m) {
+                                @Override
+                                public Class[] getParameterTypes() {
+                                    return m.getParameterTypes();
+                                }
+
+                                @Override
+                                public Type[] getGenericParameterTypes() {
+                                    return m.getGenericParameterTypes();
+                                }
+
+                                @Override
+                                public Annotation[][] getParameterAnnotations() {
+                                    return m.getParameterAnnotations();
+                                }
+
+                                @Override
+                                public Object invoke(
+                                        StaplerRequest2 req, StaplerResponse2 rsp, Object o, Object... args)
+                                        throws IllegalAccessException, InvocationTargetException {
+                                    return m.invoke(null, args);
+                                }
+                            };
+                        default:
+                            throw new IllegalArgumentException("Too many 'fromStapler' methods on " + from);
+                    }
+                }
+            };
+        }
     }
 
     /**
-     * @see StaticFunction#RETURN_NULL
+     * @see ParseMethodsHolder#RETURN_NULL
      */
     public static Object returnNull() {
         return null;


### PR DESCRIPTION

https://github.com/jenkinsci/stapler/blob/690efb4d25e9af6ef196a243ea7a7054992c56fd/core/src/main/java/org/kohsuke/stapler/Function.java#L229-L231

`Function.<clinit>` constructed a `StaticFunction` (extends `MethodFunction extends Function`), demanding `LC[Function$MethodFunction]` while `Function` was still initialising. Threads entering `ClassDescriptor.<init>` concurrently to build a `Function.InstanceFunction` held `LC[Function$MethodFunction]` and waited for `LC[Function]`, creating a permanent three-thread cycle:

```
Thread A  holds LC[Function],                waiting for LC[Function$MethodFunction]
Thread B  holds LC[Function$MethodFunction], waiting for LC[Function$InstanceFunction]
Thread C                                     waiting for LC[Function]
```

This is a standard class-init cycle per [JVMS 5.5](https://docs.oracle.com/javase/specs/jvms/se25/html/jvms-5.html#jvms-5.5), theoretically possible on any JDK. It was first observed on JDK 25 where [JEP 483](https://openjdk.org/jeps/483) (AOT/CDS, active by default: dump shows `mixed mode, sharing` without any explicit `-Xshare` flag) pre-links inner class metadata before `<clinit>` runs, widening the race window enough to trigger consistently.

Observed in propietary ATH.


## Fix

Move `PARSE_METHODS` and `RETURN_NULL` into a private `ParseMethodsHolder` inner class (lazy-holder idiom). The holder's `static {}` block runs only on first access, after `Function` and all its inner classes are fully initialised. No behaviour change on any JDK.

## Test

No unit test can trigger the race deterministically. Any classloader-based approach serialises on `LC[Function]`: all threads wait for one to finish `Function.<clinit>`, closing the window. The race requires JEP 483 pre-linking inner class metadata independently of `<clinit>`, which is JVM-internal and cannot be forced from user code. 


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
