### PR TITLE
Playing with Error Prone `ClassInitializationDeadlock`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <scmTag>HEAD</scmTag>
+    <error-prone.version>2.50.0</error-prone.version>
     <jetty.version>12.1.11</jetty.version>
     <gitHubRepo>jenkinsci/stapler</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>
@@ -158,4 +159,44 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>error-prone</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>${error-prone.version}</version>
+                </path>
+              </annotationProcessorPaths>
+              <compilerArgs>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>--should-stop=ifError=FLOW</arg>
+                <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
+                <arg>-Xplugin:ErrorProne -Xep:ClassInitializationDeadlock:ERROR</arg>
+              </compilerArgs>
+              <fork>true</fork>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
PR #787 fixed a class-initialization deadlock in `Function.java`, and I was wondering if this kind of pattern could be statically checked (as @jglick  [noted](https://github.com/jenkinsci/stapler/pull/787#issuecomment-5144685866), the same fix was applied in other places).

---

SpotBugs is configured via the parent POM and includes `IC_SUPERCLASS_USES_SUBCLASS_DURING_INITIALIZATION` (`FindPuzzlers` detector), which sounds like it should fire here. It does not.

Error Prone [`ClassInitializationDeadlock`](https://errorprone.info/bugpattern/ClassInitializationDeadlock) does catch it. It works at source (AST) level, fires on both direct and transitive subclass cases, and correctly excludes non-`static` inner classes.

This draft PR adds an `error-prone` profile. I confirmed it catches the issue by reverting #787 and running `mvn compile -Perror-prone` with `ClassInitializationDeadlock` promoted to ERROR:

> [!NOTE]
> The profile uses `<fork>true</fork>` to pass the required `--add-exports`/`--add-opens` flags as `-J-...` compiler args, keeping them out of MAVEN_OPTS and `.mvn/jvm.config`. If I'm getting this right, the forked-profile approach also sidesteps the [SezPoz concern](https://groups.google.com/g/jenkinsci-dev/c/4gjVCp1gijM/m/duC6VzJXAgAJ) about annotation-processor ordering. The default build (`mvn compile`) is unaffected.

On current master, **one `ClassInitializationDeadlock` remains** in `TreePruner.java`:

```
[ERROR] .../export/TreePruner.java:[78,50] [ClassInitializationDeadlock] Possible class initialization deadlock: ByDepth is a subclass of the containing class TreePruner
    (see https://errorprone.info/bugpattern/ClassInitializationDeadlock)
```

https://github.com/jenkinsci/stapler/blob/1557700a33da198af1320fefabed992f58f4e61d/core/src/main/java/org/kohsuke/stapler/export/TreePruner.java#L46-L78

---

I also ran the same check on jenkins core with a [similar config](https://github.com/apuig/jenkins/commit/83fa1c1f17437586279b7c0e0b8c997650131bb7) and it surfaces 8 findings:

```
[ERROR] .../hudson/security/AuthorizationStrategy.java:[229,62] [ClassInitializationDeadlock] Possible class initialization deadlock: Unsecured is a subclass of the containing class AuthorizationStrategy
    (see https://errorprone.info/bugpattern/ClassInitializationDeadlock)
[ERROR] .../hudson/slaves/RetentionStrategy.java:[156,46] [ClassInitializationDeadlock] Possible class initialization deadlock: Always is a subclass of the containing class RetentionStrategy<T>
    (see https://errorprone.info/bugpattern/ClassInitializationDeadlock)
[ERROR] .../hudson/model/TaskListener.java:[156,28] [ClassInitializationDeadlock] Possible class initialization deadlock: NullTaskListener is a subclass of the containing class TaskListener
    (see https://errorprone.info/bugpattern/ClassInitializationDeadlock)
[ERROR] .../jenkins/model/IdStrategy.java:[60,52] [ClassInitializationDeadlock] Possible class initialization deadlock: CaseInsensitive is a subclass of the containing class IdStrategy
    (see https://errorprone.info/bugpattern/ClassInitializationDeadlock)
[ERROR] .../hudson/FileSystemProvisioner.java:[51,60] [ClassInitializationDeadlock] Possible class initialization deadlock: Default is a subclass of the containing class FileSystemProvisioner
    (see https://errorprone.info/bugpattern/ClassInitializationDeadlock)
[ERROR] .../hudson/util/ProcessTree.java:[496,55] [ClassInitializationDeadlock] Possible class initialization deadlock: Local is a subclass of the containing class ProcessTree
    (see https://errorprone.info/bugpattern/ClassInitializationDeadlock)
[ERROR] .../jenkins/model/queue/QueueIdStrategy.java:[20,55] [ClassInitializationDeadlock] Possible class initialization deadlock: DefaultStrategy is a subclass of the containing class QueueIdStrategy
    (see https://errorprone.info/bugpattern/ClassInitializationDeadlock)
[ERROR] .../jenkins/model/ProjectNamingStrategy.java:[104,76] [ClassInitializationDeadlock] Possible class initialization deadlock: DefaultProjectNamingStrategy is a subclass of the containing class ProjectNamingStrategy
    (see https://errorprone.info/bugpattern/ClassInitializationDeadlock)
```

---

:speaking_head:  The fix pattern is the same as #787. Before opening any PRs for these, I wanted to share the methodology first and get a sanity check on whether these are worth pursuing.

---

#### Error Prone ??

The short answer to "which static analysis tool should we use?" is: yes.

errorprone is not adopted in jenkins ecosystem, but I found some data points:

* **EP annotations are actively excluded in jenkins core.** [`error_prone_annotations`](https://github.com/jenkinsci/jenkins/blob/78ba741250ab4f0b2bc21046f59354f28d1fd253/core/pom.xml#L95-L99) is excluded as a transitive dep of Guava. No `Xplugin:ErrorProne` is wired anywhere in `jenkinsci/jenkins` or `jenkinsci/stapler`.

* **EP has been run locally by contributors** PR [jenkinsci/jenkins#5510](https://github.com/jenkinsci/jenkins/pull/5510) fixed several EP violations via [a local run](https://github.com/jenkinsci/jenkins/pull/5510#issuecomment-846085626).

* **`opentelemetry-plugin` has an opt-in EP profile with an explicit placeholder comment.** https://github.com/jenkinsci/opentelemetry-plugin/blob/559d9e39a519e1581f5e1e11bed0646c83ca887a/pom.xml#L565-L566