### PR TITLE
Remove TreePruner.DEFAULT and introduce ByDepth.DEFAULT

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/BytecodeReadingParanamer.java
+++ b/core/src/main/java/org/kohsuke/stapler/BytecodeReadingParanamer.java
@@ -37,7 +37,6 @@ import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Modifier;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -62,18 +61,15 @@ final class BytecodeReadingParanamer {
     private static final Logger LOGGER = Logger.getLogger(BytecodeReadingParanamer.class.getName());
     private static final Object PLACEHOLDER = new Object();
 
-    private static final Map<String, String> primitives = new HashMap<>() {
-        {
-            put("int", "I");
-            put("boolean", "Z");
-            put("byte", "B");
-            put("char", "C");
-            put("short", "S");
-            put("float", "F");
-            put("long", "J");
-            put("double", "D");
-        }
-    };
+    private static final Map<String, String> primitives = Map.ofEntries(
+            Map.entry("int", "I"),
+            Map.entry("boolean", "Z"),
+            Map.entry("byte", "B"),
+            Map.entry("char", "C"),
+            Map.entry("short", "S"),
+            Map.entry("float", "F"),
+            Map.entry("long", "J"),
+            Map.entry("double", "D"));
 
     static String[] lookupParameterNames(Executable executable) throws IOException {
         String genericString = executable.toGenericString();

--- a/core/src/main/java/org/kohsuke/stapler/export/TreePruner.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/TreePruner.java
@@ -44,6 +44,12 @@ public abstract class TreePruner {
     }
 
     public static class ByDepth extends TreePruner {
+        /**
+         * Probably the most common {@link TreePruner} that just visits the top object and its properties,
+         * but none of the referenced objects.
+         */
+        public static final ByDepth DEFAULT = new ByDepth(1);
+
         final int n;
         private ByDepth next;
 
@@ -70,10 +76,4 @@ public abstract class TreePruner {
             return next();
         }
     }
-
-    /**
-     * Probably the most common {@link TreePruner} that just visits the top object and its properties,
-     * but none of the referenced objects.
-     */
-    public static final TreePruner DEFAULT = new ByDepth(1);
 }

--- a/core/src/test/java/org/kohsuke/stapler/export/ModelTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/ModelTest.java
@@ -113,7 +113,8 @@ class ModelTest {
     void skipNull() throws Exception {
         StringWriter sw = new StringWriter();
         SomeNullProperty o = new SomeNullProperty();
-        builder.get(SomeNullProperty.class).writeTo(o, TreePruner.DEFAULT, Flavor.JSON.createDataWriter(o, sw, config));
+        builder.get(SomeNullProperty.class)
+                .writeTo(o, TreePruner.ByDepth.DEFAULT, Flavor.JSON.createDataWriter(o, sw, config));
         assertEquals(
                 "{'_class':'SomeNullProperty','bbb':'bbb','ccc':null,'ddd':'ddd'}",
                 sw.toString().replace('"', '\''));


### PR DESCRIPTION
from #788.

Removes `TreePruner.DEFAULT` and replaces it with `ByDepth.DEFAULT`.
`ClassInitializationDeadlock` fires when an outer class's `<clinit>` instantiates a subclass; `ByDepth` initializing an instance of itself has no cross-class cycle and does not trigger `ClassInitializationDeadlock`.

Why not simply remove and use `new ByDepth(1)`? : prbably fine as well, but `ByDepth` lazily caches its depth+1 successor per instance, so moving the constant into `ByDepth` itself preserves baseline allocations. 


Downstream: jenkinsci/mcp-server-plugin#220


Other known users of `TreePruner.DEFAULT` from a [usage-in-plugins](https://github.com/jenkins-infra/usage-in-plugins) scan. None are in [jenkinsci/bom](https://github.com/jenkinsci/bom); all have modest installations. If this PR is accepted, companion issues should be opened on each:

- [BlazeMeterJenkinsPlugin](https://plugins.jenkins.io/BlazeMeterJenkinsPlugin/) ([Blazemeter/blazemeter-jenkins-plugin](https://github.com/Blazemeter/blazemeter-jenkins-plugin))
- [image-gallery](https://plugins.jenkins.io/image-gallery/) ([biouno/image-gallery-plugin](https://github.com/biouno/image-gallery-plugin))
- [label-linked-jobs](https://plugins.jenkins.io/label-linked-jobs/) ([jenkinsci/label-linked-jobs-plugin](https://github.com/jenkinsci/label-linked-jobs-plugin))
- [micro-focus-performance-center-integration](https://plugins.jenkins.io/micro-focus-performance-center-integration/) ([jenkinsci/micro-focus-performance-center-integration-plugin](https://github.com/jenkinsci/micro-focus-performance-center-integration-plugin))
- [requests](https://plugins.jenkins.io/requests/) ([jenkinsci/requests-plugin](https://github.com/jenkinsci/requests-plugin))

---

:speaking_head:  Second commit, replaces the double-brace `HashMap` initializer in `BytecodeReadingParanamer` with `Map.ofEntries(...)`, a boy-scout cleanup with same semantics that makes default errorprone config happy. [`DoubleBraceInitialization`](https://errorprone.info/bugpattern/DoubleBraceInitialization).

---

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed