### PR TITLE
Adapt processor tests to Elementary 3 output directories

### DIFF
--- a/core/src/test/java/org/kohsuke/stapler/jsr269/ConstructorProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/ConstructorProcessorTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.karuslabs.elementary.Results;
 import com.karuslabs.elementary.junit.JavacExtension;
+import com.karuslabs.elementary.junit.annotations.Generation;
 import com.karuslabs.elementary.junit.annotations.Inline;
 import com.karuslabs.elementary.junit.annotations.Options;
 import com.karuslabs.elementary.junit.annotations.Processors;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(JavacExtension.class)
 @Options("-Werror")
 @Processors(ConstructorProcessor.class)
+@Generation(classes = Utils.CLASS_OUTPUT)
 class ConstructorProcessorTest {
 
     @Inline(
@@ -39,7 +41,7 @@ class ConstructorProcessorTest {
         assertEquals(Set.of("Generating some/pkg/Stuff.stapler"), diagnostics);
         assertEquals(
                 "{constructor=count,name}",
-                Utils.normalizeProperties(Utils.getGeneratedResource(results.sources, "some/pkg/Stuff.stapler")));
+                Utils.normalizeProperties(Utils.getGeneratedResource("some/pkg/Stuff.stapler")));
     }
 
     @Inline(
@@ -58,7 +60,7 @@ class ConstructorProcessorTest {
         assertEquals(Set.of("Generating some/pkg/Stuff.stapler"), diagnostics);
         assertEquals(
                 "{constructor=name,count}",
-                Utils.normalizeProperties(Utils.getGeneratedResource(results.sources, "some/pkg/Stuff.stapler")));
+                Utils.normalizeProperties(Utils.getGeneratedResource("some/pkg/Stuff.stapler")));
     }
 
     @Inline(
@@ -79,7 +81,7 @@ class ConstructorProcessorTest {
         assertEquals(Set.of("Generating some/pkg/Stuff.stapler"), diagnostics);
         assertEquals(
                 "{constructor=count,name}",
-                Utils.normalizeProperties(Utils.getGeneratedResource(results.sources, "some/pkg/Stuff.stapler")));
+                Utils.normalizeProperties(Utils.getGeneratedResource("some/pkg/Stuff.stapler")));
     }
 
     @Inline(
@@ -196,7 +198,7 @@ class ConstructorProcessorTest {
                 .collect(Collectors.toSet());
         assertEquals(Set.of("Generating some/pkg/Stuff.stapler"), diagnostics);
         assertThat(
-                Utils.getGeneratedResource(results.sources, "some/pkg/Stuff.stapler"),
+                Utils.getGeneratedResource("some/pkg/Stuff.stapler"),
                 not(containsString(Integer.toString(Year.now().getValue()))));
     }
 }

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/ExportedBeanAnnotationProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/ExportedBeanAnnotationProcessorTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.karuslabs.elementary.Results;
 import com.karuslabs.elementary.junit.JavacExtension;
+import com.karuslabs.elementary.junit.annotations.Generation;
 import com.karuslabs.elementary.junit.annotations.Inline;
 import com.karuslabs.elementary.junit.annotations.Options;
 import com.karuslabs.elementary.junit.annotations.Processors;
@@ -18,6 +19,7 @@ import org.jvnet.hudson.annotation_indexer.AnnotationProcessorImpl;
 @ExtendWith(JavacExtension.class)
 @Options("-Werror")
 @Processors({AnnotationProcessorImpl.class, ExportedBeanAnnotationProcessor.class})
+@Generation(classes = Utils.CLASS_OUTPUT)
 class ExportedBeanAnnotationProcessorTest {
 
     private void assertEqualsCRLF(String s1, String s2) {
@@ -44,14 +46,12 @@ class ExportedBeanAnnotationProcessorTest {
         assertEquals(Set.of("Generating some/pkg/Stuff.javadoc"), diagnostics);
         assertEqualsCRLF(
                 "some.pkg.Stuff\n",
-                Utils.getGeneratedResource(
-                        results.sources, "META-INF/services/annotations/org.kohsuke.stapler.export.ExportedBean"));
+                Utils.getGeneratedResource("META-INF/services/annotations/org.kohsuke.stapler.export.ExportedBean"));
         assertEqualsCRLF(
-                "some.pkg.Stuff\n",
-                Utils.getGeneratedResource(results.sources, ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
+                "some.pkg.Stuff\n", Utils.getGeneratedResource(ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
         assertEquals(
                 "{getDisplayName=This gets the display name. }",
-                Utils.normalizeProperties(Utils.getGeneratedResource(results.sources, "some/pkg/Stuff.javadoc")));
+                Utils.normalizeProperties(Utils.getGeneratedResource("some/pkg/Stuff.javadoc")));
     }
 
     @Inline(
@@ -71,14 +71,11 @@ class ExportedBeanAnnotationProcessorTest {
         assertEquals(Set.of("Generating some/pkg/Stuff.javadoc"), diagnostics);
         assertEqualsCRLF(
                 "some.pkg.Stuff\n",
-                Utils.getGeneratedResource(
-                        results.sources, "META-INF/services/annotations/org.kohsuke.stapler.export.ExportedBean"));
+                Utils.getGeneratedResource("META-INF/services/annotations/org.kohsuke.stapler.export.ExportedBean"));
         assertEqualsCRLF(
-                "some.pkg.Stuff\n",
-                Utils.getGeneratedResource(results.sources, ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
+                "some.pkg.Stuff\n", Utils.getGeneratedResource(ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
         // TODO should it be null, i.e. is it desired to create an empty *.javadoc file?
-        assertEquals(
-                "{}", Utils.normalizeProperties(Utils.getGeneratedResource(results.sources, "some/pkg/Stuff.javadoc")));
+        assertEquals("{}", Utils.normalizeProperties(Utils.getGeneratedResource("some/pkg/Stuff.javadoc")));
     }
 
     @Inline(
@@ -106,13 +103,12 @@ class ExportedBeanAnnotationProcessorTest {
                 .collect(Collectors.toSet());
         assertEquals(Set.of("Generating some/pkg/Super.javadoc"), diagnostics);
         /* #7188605: broken in JDK 6u33 + org.jvnet.hudson:annotation-indexer:1.2:
-        assertEquals("some.pkg.Stuff\n", Utils.getGeneratedResource(results.sources, "META-INF/services/annotations/org.kohsuke.stapler.export.ExportedBean"));
+        assertEquals("some.pkg.Stuff\n", Utils.getGeneratedResource("META-INF/services/annotations/org.kohsuke.stapler.export.ExportedBean"));
         */
         // TODO is it intentional that these are not listed here? (example: hudson.plugins.mercurial.MercurialSCM)
         assertEqualsCRLF(
-                "some.pkg.Super\n",
-                Utils.getGeneratedResource(results.sources, ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
-        assertNull(Utils.normalizeProperties(Utils.getGeneratedResource(results.sources, "some/pkg/Stuff.javadoc")));
+                "some.pkg.Super\n", Utils.getGeneratedResource(ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
+        assertNull(Utils.normalizeProperties(Utils.getGeneratedResource("some/pkg/Stuff.javadoc")));
     }
 
     @Inline(
@@ -142,11 +138,10 @@ class ExportedBeanAnnotationProcessorTest {
         assertEquals(Set.of("Generating some/pkg/Stuff.javadoc", "Generating some/pkg/MoreStuff.javadoc"), diagnostics);
         assertEqualsCRLF(
                 "some.pkg.MoreStuff\nsome.pkg.Stuff\n",
-                Utils.getGeneratedResource(
-                        results.sources, "META-INF/services/annotations/org.kohsuke.stapler.export.ExportedBean"));
+                Utils.getGeneratedResource("META-INF/services/annotations/org.kohsuke.stapler.export.ExportedBean"));
         assertEqualsCRLF(
                 "some.pkg.MoreStuff\nsome.pkg.Stuff\n",
-                Utils.getGeneratedResource(results.sources, ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
+                Utils.getGeneratedResource(ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
     }
 
     // TODO nested classes - currently saved as qualified rather than binary name, intentional?

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/QueryParameterAnnotationProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/QueryParameterAnnotationProcessorTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.karuslabs.elementary.Results;
 import com.karuslabs.elementary.junit.JavacExtension;
+import com.karuslabs.elementary.junit.annotations.Generation;
 import com.karuslabs.elementary.junit.annotations.Inline;
 import com.karuslabs.elementary.junit.annotations.Options;
 import com.karuslabs.elementary.junit.annotations.Processors;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(JavacExtension.class)
 @Options("-Werror")
 @Processors(QueryParameterAnnotationProcessor.class)
+@Generation(classes = Utils.CLASS_OUTPUT)
 class QueryParameterAnnotationProcessorTest {
 
     @Inline(
@@ -36,8 +38,8 @@ class QueryParameterAnnotationProcessorTest {
         assertEquals(
                 Set.of("Generating some/pkg/Stuff/doOneThing.stapler", "Generating some/pkg/Stuff/doAnother.stapler"),
                 diagnostics);
-        assertEquals("key", Utils.getGeneratedResource(results.sources, "some/pkg/Stuff/doOneThing.stapler"));
-        assertEquals("name,address", Utils.getGeneratedResource(results.sources, "some/pkg/Stuff/doAnother.stapler"));
+        assertEquals("key", Utils.getGeneratedResource("some/pkg/Stuff/doOneThing.stapler"));
+        assertEquals("name,address", Utils.getGeneratedResource("some/pkg/Stuff/doAnother.stapler"));
     }
 
     @Inline(
@@ -61,7 +63,7 @@ class QueryParameterAnnotationProcessorTest {
                 .map(d -> d.getMessage(Locale.ENGLISH))
                 .collect(Collectors.toSet());
         assertEquals(Set.of("Generating some/pkg/Stuff/doBuild.stapler"), diagnostics);
-        assertEquals("req,rsp,delay", Utils.getGeneratedResource(results.sources, "some/pkg/Stuff/doBuild.stapler"));
+        assertEquals("req,rsp,delay", Utils.getGeneratedResource("some/pkg/Stuff/doBuild.stapler"));
     }
 
     // TODO nested classes use qualified rather than binary name

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/Utils.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/Utils.java
@@ -3,23 +3,21 @@ package org.kohsuke.stapler.jsr269;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.UncheckedIOException;
-import java.util.List;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Properties;
 import java.util.TreeMap;
-import javax.tools.JavaFileObject;
-import javax.tools.StandardLocation;
 
 class Utils {
-    public static String getGeneratedResource(List<JavaFileObject> generated, String filename) {
-        JavaFileObject fo = generated.stream()
-                .filter(it -> it.getName().equals("/" + StandardLocation.CLASS_OUTPUT + "/" + filename))
-                .findFirst()
-                .orElse(null);
-        if (fo == null) {
+    static final String CLASS_OUTPUT = "target/elementary-classes";
+
+    public static String getGeneratedResource(String filename) {
+        Path resource = Path.of(CLASS_OUTPUT, filename);
+        if (!Files.exists(resource)) {
             return null;
         }
         try {
-            return fo.getCharContent(true).toString();
+            return Files.readString(resource);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
The Elementary 3 upgrade changes generated output from in-memory file objects to temporary directories. The annotation-processor tests were still searching `Results.sources`, so the processors ran but resource assertions received `null`.

This configures the affected tests with Elementary 3's `@Generation` output directory and reads generated resources from that class output. The existing processor and diagnostic assertions remain unchanged.

Verification:
- `JAVA_HOME=$(/usr/libexec/java_home -v 25) mvn -B -T 1C clean verify`
- all five reactor modules passed
- Checkstyle, SpotBugs, and Spotless passed
- the 15 affected annotation-processor tests passed
